### PR TITLE
Updated bluefin_original.yaml with unreleased fixes #10747 #10748

### DIFF
--- a/cfg/bluefin_original.yaml
+++ b/cfg/bluefin_original.yaml
@@ -173,7 +173,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/core_job_abort_0'
+              $ref: '#/components/schemas/core_job_abort'
   /core/job_update:
     post:
       tags:
@@ -205,7 +205,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/core_job_wait_0'
+              $ref: '#/components/schemas/core_job_wait'
   /core/ping:
     get:
       tags:
@@ -237,7 +237,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/core_ping_remote_0'
+              $ref: '#/components/schemas/core_ping_remote'
   /core/resize_shell:
     post:
       tags:
@@ -303,7 +303,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/core_set_debug_mode_0'
+              $ref: '#/components/schemas/core_set_debug_mode'
   /acme/dns/authenticator:
     get:
       tags:
@@ -354,7 +354,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/acme_dns_authenticator_create_0'
+              $ref: '#/components/schemas/acme_dns_authenticator_create'
   /acme/dns/authenticator/id/{id}:
     delete:
       tags:
@@ -405,6 +405,11 @@ paths:
       description: |+
         Update DNS Authenticator of `id`
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/acme_dns_authenticator_update_by_id'
   /acme/dns/authenticator/authenticator_schemas:
     get:
       tags:
@@ -462,7 +467,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/activedirectory_update_0'
+              $ref: '#/components/schemas/activedirectory_update'
   /activedirectory/change_trust_account_pw:
     get:
       tags:
@@ -508,7 +513,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/activedirectory_domain_info_0'
+              $ref: '#/components/schemas/activedirectory_domain_info'
   /activedirectory/get_spn_list:
     get:
       tags:
@@ -557,7 +562,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/activedirectory_leave_0'
+              $ref: '#/components/schemas/activedirectory_leave'
   /activedirectory/nss_info_choices:
     get:
       tags:
@@ -599,7 +604,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/alert_dismiss_0'
+              $ref: '#/components/schemas/alert_dismiss'
   /alert/list:
     get:
       tags:
@@ -648,7 +653,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/alert_restore_0'
+              $ref: '#/components/schemas/alert_restore'
   /alertclasses:
     get:
       tags:
@@ -676,7 +681,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/alertclasses_update_0'
+              $ref: '#/components/schemas/alertclasses_update'
   /alertservice:
     get:
       tags:
@@ -726,7 +731,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/alertservice_create_0'
+              $ref: '#/components/schemas/alertservice_create'
   /alertservice/id/{id}:
     delete:
       tags:
@@ -773,6 +778,11 @@ paths:
           schema:
             type: integer
       description: Update Alert Service of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/alertservice_update_by_id'
   /alertservice/get_instance:
     post:
       tags:
@@ -820,7 +830,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/alertservice_test_0'
+              $ref: '#/components/schemas/alertservice_test'
   /api_key:
     get:
       tags:
@@ -869,7 +879,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api_key_create_0'
+              $ref: '#/components/schemas/api_key_create'
   /api_key/id/{id}:
     delete:
       tags:
@@ -919,6 +929,11 @@ paths:
         Update API Key `id`.
 
         Specify `reset: true` to reset this API Key.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api_key_update_by_id'
   /api_key/get_instance:
     post:
       tags:
@@ -1007,7 +1022,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/auth_terminate_session_0'
+              $ref: '#/components/schemas/auth_terminate_session'
   /auth/two_factor_auth:
     get:
       tags:
@@ -1049,7 +1064,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/auth_twofactor_update_0'
+              $ref: '#/components/schemas/auth_twofactor_update'
   /auth/twofactor/provisioning_uri:
     get:
       tags:
@@ -1089,7 +1104,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/auth_twofactor_verify_0'
+              $ref: '#/components/schemas/auth_twofactor_verify'
   /boot/attach:
     post:
       tags:
@@ -1125,7 +1140,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/boot_detach_0'
+              $ref: '#/components/schemas/boot_detach'
   /boot/get_disks:
     get:
       tags:
@@ -1201,7 +1216,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/boot_set_scrub_interval_0'
+              $ref: '#/components/schemas/boot_set_scrub_interval'
   /bootenv:
     get:
       tags:
@@ -1256,7 +1271,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/bootenv_create_0'
+              $ref: '#/components/schemas/bootenv_create'
   /bootenv/id/{id}:
     delete:
       tags:
@@ -1306,6 +1321,11 @@ paths:
           schema:
             type: string
       description: Update `id` boot environment name with a new provided valid `name`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bootenv_update_by_id'
   /bootenv/id/{id}/activate:
     post:
       tags:
@@ -1322,6 +1342,11 @@ paths:
           schema:
             type: string
       description: Activates boot environment `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bootenv_activate_by_id'
   /bootenv/get_instance:
     post:
       tags:
@@ -1360,6 +1385,11 @@ paths:
         Sets attributes boot environment `id`.
 
         Currently only `keep` attribute is allowed.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bootenv_set_attribute_by_id'
   /catalog:
     get:
       tags:
@@ -1405,7 +1435,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/catalog_create_0'
+              $ref: '#/components/schemas/catalog_create'
   /catalog/id/{id}:
     delete:
       tags:
@@ -1452,6 +1482,11 @@ paths:
           schema:
             type: string
       description: ""
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/catalog_update_by_id'
   /catalog/get_instance:
     post:
       tags:
@@ -1532,7 +1567,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/catalog_sync_0'
+              $ref: '#/components/schemas/catalog_sync'
   /catalog/sync_all:
     get:
       tags:
@@ -1563,7 +1598,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/catalog_validate_0'
+              $ref: '#/components/schemas/catalog_validate'
   /certificate:
     get:
       tags:
@@ -1633,7 +1668,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/certificate_create_0'
+              $ref: '#/components/schemas/certificate_create'
   /certificate/id/{id}:
     delete:
       tags:
@@ -1657,6 +1692,11 @@ paths:
         and the certificate is not deleted from the system. However, if `force` is set to True, certificate is deleted
         from the system even if some error occurred while revoking the certificate with the ACME Server
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/certificate_delete_by_id'
     get:
       tags:
         - certificate
@@ -1694,6 +1734,11 @@ paths:
         When `revoked` is enabled, the specified cert `id` is revoked and if it belongs to a CA chain which
         exists on this system, its serial number is added to the CA's certificate revocation list.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/certificate_update_by_id'
   /certificate/acme_server_choices:
     get:
       tags:
@@ -1861,7 +1906,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/certificateauthority_create_0'
+              $ref: '#/components/schemas/certificateauthority_create'
   /certificateauthority/id/{id}:
     delete:
       tags:
@@ -1917,6 +1962,11 @@ paths:
         If `revoked` is enabled, the CA and its complete chain is marked as revoked and added to the CA's
         certificate revocation list.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/certificateauthority_update_by_id'
   /certificateauthority/ca_sign_csr:
     post:
       tags:
@@ -1939,7 +1989,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/certificateauthority_ca_sign_csr_0'
+              $ref: '#/components/schemas/certificateauthority_ca_sign_csr'
   /certificateauthority/get_instance:
     post:
       tags:
@@ -2044,7 +2094,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/chart_release_create_0'
+              $ref: '#/components/schemas/chart_release_create'
   /chart/release/id/{id}:
     delete:
       tags:
@@ -2065,6 +2115,11 @@ paths:
 
         This will delete the chart release from the kubernetes cluster and also remove any associated volumes / data.
         To clarify, host path volumes will not be deleted which live outside the chart release dataset.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/chart_release_delete_by_id'
     get:
       tags:
         - chart.release
@@ -2114,6 +2169,11 @@ paths:
 
         `values` is configuration specified for the catalog item version in question which will be used to
         create the chart release.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/chart_release_update_by_id'
   /chart/release/certificate_authority_choices:
     get:
       tags:
@@ -2151,7 +2211,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/chart_release_events_0'
+              $ref: '#/components/schemas/chart_release_events'
   /chart/release/get_chart_releases_using_chart_release_images:
     post:
       tags:
@@ -2167,7 +2227,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/chart_release_get_chart_releases_using_chart_release_images_0'
+              $ref: '#/components/schemas/chart_release_get_chart_releases_using_chart_release_images'
   /chart/release/get_instance:
     post:
       tags:
@@ -2217,7 +2277,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/chart_release_pod_console_choices_0'
+              $ref: '#/components/schemas/chart_release_pod_console_choices'
   /chart/release/pod_logs:
     post:
       tags:
@@ -2261,7 +2321,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/chart_release_pod_logs_choices_0'
+              $ref: '#/components/schemas/chart_release_pod_logs_choices'
   /chart/release/pod_status:
     post:
       tags:
@@ -2277,7 +2337,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/chart_release_pod_status_0'
+              $ref: '#/components/schemas/chart_release_pod_status'
   /chart/release/pull_container_images:
     post:
       tags:
@@ -2315,7 +2375,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/chart_release_redeploy_0'
+              $ref: '#/components/schemas/chart_release_redeploy'
   /chart/release/remove_ix_volume:
     post:
       tags:
@@ -2517,7 +2577,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/cloudsync_create_0'
+              $ref: '#/components/schemas/cloudsync_create'
   /cloudsync/id/{id}:
     delete:
       tags:
@@ -2564,6 +2624,11 @@ paths:
           schema:
             type: integer
       description: Updates the cloud_sync entry `id` with `data`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/cloudsync_update_by_id'
   /cloudsync/id/{id}/abort:
     post:
       tags:
@@ -2580,6 +2645,11 @@ paths:
           schema:
             type: integer
       description: Aborts cloud sync task.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/cloudsync_abort_by_id'
   /cloudsync/create_bucket:
     post:
       tags:
@@ -2630,7 +2700,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/cloudsync_list_buckets_0'
+              $ref: '#/components/schemas/cloudsync_list_buckets'
   /cloudsync/list_directory:
     post:
       tags:
@@ -2661,7 +2731,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/cloudsync_list_directory_0'
+              $ref: '#/components/schemas/cloudsync_list_directory'
   /cloudsync/onedrive_list_drives:
     post:
       tags:
@@ -2679,7 +2749,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/cloudsync_onedrive_list_drives_0'
+              $ref: '#/components/schemas/cloudsync_onedrive_list_drives'
   /cloudsync/providers:
     get:
       tags:
@@ -2745,6 +2815,11 @@ paths:
           schema:
             type: integer
       description: Create the opposite of cloud sync task `id` (PULL if it was PUSH and vice versa).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/cloudsync_restore_by_id'
   /cloudsync/id/{id}/sync:
     post:
       tags:
@@ -2761,6 +2836,11 @@ paths:
           schema:
             type: integer
       description: Run the cloud_sync job `id`, syncing the local data to remote.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/cloudsync_sync_by_id'
   /cloudsync/sync_onetime:
     post:
       tags:
@@ -2825,7 +2905,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/cloudsync_credentials_create_0'
+              $ref: '#/components/schemas/cloudsync_credentials_create'
   /cloudsync/credentials/id/{id}:
     delete:
       tags:
@@ -2872,6 +2952,11 @@ paths:
           schema:
             type: integer
       description: Update Cloud Sync Credentials of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/cloudsync_credentials_update_by_id'
   /cloudsync/credentials/get_instance:
     post:
       tags:
@@ -2906,7 +2991,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/cloudsync_credentials_verify_0'
+              $ref: '#/components/schemas/cloudsync_credentials_verify'
   /cluster/utils/is_clustered:
     get:
       tags:
@@ -2940,7 +3025,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/config_reset_0'
+              $ref: '#/components/schemas/config_reset'
   /config/save:
     post:
       tags:
@@ -2967,7 +3052,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/config_save_0'
+              $ref: '#/components/schemas/config_save'
   /config/upload:
     post:
       tags:
@@ -3013,7 +3098,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/container_update_0'
+              $ref: '#/components/schemas/container_update'
   /container/prune:
     post:
       tags:
@@ -3035,7 +3120,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/container_prune_0'
+              $ref: '#/components/schemas/container_prune'
   /container/image:
     get:
       tags:
@@ -3089,6 +3174,11 @@ paths:
           schema:
             type: string
       description: '`options.force` should be used to force delete an image even if it''s in use by a stopped container.'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/container_image_delete_by_id'
     get:
       tags:
         - container.image
@@ -3125,7 +3215,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/container_image_get_chart_releases_consuming_image_0'
+              $ref: '#/components/schemas/container_image_get_chart_releases_consuming_image'
   /container/image/get_instance:
     post:
       tags:
@@ -3167,7 +3257,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/container_image_pull_0'
+              $ref: '#/components/schemas/container_image_pull'
   /cronjob:
     get:
       tags:
@@ -3218,7 +3308,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/cronjob_create_0'
+              $ref: '#/components/schemas/cronjob_create'
   /cronjob/id/{id}:
     delete:
       tags:
@@ -3265,6 +3355,11 @@ paths:
           schema:
             type: integer
       description: Update cronjob of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/cronjob_update_by_id'
   /cronjob/get_instance:
     post:
       tags:
@@ -3330,7 +3425,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ctdb_general_ips_0'
+              $ref: '#/components/schemas/ctdb_general_ips'
   /ctdb/general/listnodes:
     get:
       tags:
@@ -3412,7 +3507,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ctdb_general_status_0'
+              $ref: '#/components/schemas/ctdb_general_status'
   /ctdb/private/ips:
     get:
       tags:
@@ -3461,7 +3556,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ctdb_private_ips_create_0'
+              $ref: '#/components/schemas/ctdb_private_ips_create'
   /ctdb/private/ips/id/{id}:
     get:
       tags:
@@ -3497,6 +3592,11 @@ paths:
 
         `id` integer representing the PNN value for the node.
         `enable` boolean. When True, enable the node else disable the node.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ctdb_private_ips_update_by_id'
   /ctdb/private/ips/get_instance:
     post:
       tags:
@@ -3577,7 +3677,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ctdb_public_ips_create_0'
+              $ref: '#/components/schemas/ctdb_public_ips_create'
   /ctdb/public/ips/id/{id}:
     delete:
       tags:
@@ -3598,6 +3698,11 @@ paths:
         If `pnn` is not specified, then the operation applies to the current node.
         In order to remove an address cluster-wide, this method must be called on
         every node where the public IP address is configured.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ctdb_public_ips_delete_by_id'
     get:
       tags:
         - ctdb.public.ips
@@ -3657,7 +3762,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ctdb_public_ips_interface_choices_0'
+              $ref: '#/components/schemas/ctdb_public_ips_interface_choices'
   /device/get_info:
     post:
       tags:
@@ -3673,7 +3778,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/device_get_info_0'
+              $ref: '#/components/schemas/device_get_info'
   /device/gpu_pci_ids_choices:
     get:
       tags:
@@ -3826,6 +3931,11 @@ paths:
         Email of log level LOG_INFO is issued when disk temperature crosses `informational`.
 
         If temperature of a disk changes by `difference` degree Celsius since the last report, SMART reports this.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/disk_update_by_id'
   /disk/get_instance:
     post:
       tags:
@@ -3862,7 +3972,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/disk_get_unused_0'
+              $ref: '#/components/schemas/disk_get_unused'
   /disk/resize:
     post:
       tags:
@@ -3908,7 +4018,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/disk_smart_attributes_0'
+              $ref: '#/components/schemas/disk_smart_attributes'
   /disk/temperature:
     post:
       tags:
@@ -3958,7 +4068,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/disk_temperature_alerts_0'
+              $ref: '#/components/schemas/disk_temperature_alerts'
   /disk/temperatures:
     post:
       tags:
@@ -4064,7 +4174,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/dyndns_update_0'
+              $ref: '#/components/schemas/dyndns_update'
   /dyndns/provider_choices:
     get:
       tags:
@@ -4138,6 +4248,11 @@ paths:
           schema:
             type: integer
       description: ""
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/enclosure_update_by_id'
   /enclosure/get_instance:
     post:
       tags:
@@ -4211,7 +4326,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/failover_update_0'
+              $ref: '#/components/schemas/failover_update'
   /failover/become_passive:
     get:
       tags:
@@ -4412,7 +4527,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/failover_sync_to_peer_0'
+              $ref: '#/components/schemas/failover_sync_to_peer'
   /failover/unlock:
     post:
       tags:
@@ -4430,7 +4545,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/failover_unlock_0'
+              $ref: '#/components/schemas/failover_unlock'
   /failover/upgrade:
     post:
       tags:
@@ -4457,7 +4572,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/failover_upgrade_0'
+              $ref: '#/components/schemas/failover_upgrade'
   /failover/upgrade_finish:
     get:
       tags:
@@ -4510,7 +4625,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_acl_is_trivial_0'
+              $ref: '#/components/schemas/filesystem_acl_is_trivial'
   /filesystem/can_access_as_user:
     post:
       tags:
@@ -4556,7 +4671,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_chown_0'
+              $ref: '#/components/schemas/filesystem_chown'
   /filesystem/default_acl_choices:
     post:
       tags:
@@ -4575,7 +4690,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_default_acl_choices_0'
+              $ref: '#/components/schemas/filesystem_default_acl_choices'
   /filesystem/get:
     post:
       tags:
@@ -4594,7 +4709,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_get_0'
+              $ref: '#/components/schemas/filesystem_get'
   /filesystem/get_default_acl:
     post:
       tags:
@@ -4631,7 +4746,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_get_dosmode_0'
+              $ref: '#/components/schemas/filesystem_get_dosmode'
   /filesystem/getacl:
     post:
       tags:
@@ -4693,7 +4808,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_is_immutable_0'
+              $ref: '#/components/schemas/filesystem_is_immutable'
   /filesystem/listdir:
     post:
       tags:
@@ -4744,7 +4859,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_mkdir_0'
+              $ref: '#/components/schemas/filesystem_mkdir'
   /filesystem/put:
     post:
       tags:
@@ -4779,7 +4894,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_set_dosmode_0'
+              $ref: '#/components/schemas/filesystem_set_dosmode'
   /filesystem/set_immutable:
     post:
       tags:
@@ -4846,7 +4961,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_setacl_0'
+              $ref: '#/components/schemas/filesystem_setacl'
   /filesystem/setperm:
     post:
       tags:
@@ -4889,7 +5004,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_setperm_0'
+              $ref: '#/components/schemas/filesystem_setperm'
   /filesystem/stat:
     post:
       tags:
@@ -4911,7 +5026,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_stat_0'
+              $ref: '#/components/schemas/filesystem_stat'
   /filesystem/statfs:
     post:
       tags:
@@ -4936,7 +5051,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_statfs_0'
+              $ref: '#/components/schemas/filesystem_statfs'
   /filesystem/acltemplate:
     get:
       tags:
@@ -4982,7 +5097,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_acltemplate_create_0'
+              $ref: '#/components/schemas/filesystem_acltemplate_create'
   /filesystem/acltemplate/id/{id}:
     delete:
       tags:
@@ -5029,6 +5144,11 @@ paths:
           schema:
             type: integer
       description: update filesystem ACL template with `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/filesystem_acltemplate_update_by_id'
   /filesystem/acltemplate/by_path:
     post:
       tags:
@@ -5054,7 +5174,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/filesystem_acltemplate_by_path_0'
+              $ref: '#/components/schemas/filesystem_acltemplate_by_path'
   /filesystem/acltemplate/get_instance:
     post:
       tags:
@@ -5162,7 +5282,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ftp_update_0'
+              $ref: '#/components/schemas/ftp_update'
   /gluster/eventsd/create:
     post:
       tags:
@@ -5189,7 +5309,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_eventsd_create_0'
+              $ref: '#/components/schemas/gluster_eventsd_create'
   /gluster/eventsd/delete:
     post:
       tags:
@@ -5208,7 +5328,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_eventsd_delete_0'
+              $ref: '#/components/schemas/gluster_eventsd_delete'
   /gluster/eventsd/sync:
     get:
       tags:
@@ -5251,7 +5371,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_fuse_is_mounted_0'
+              $ref: '#/components/schemas/gluster_fuse_is_mounted'
   /gluster/fuse/mount:
     post:
       tags:
@@ -5274,7 +5394,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_fuse_mount_0'
+              $ref: '#/components/schemas/gluster_fuse_mount'
   /gluster/fuse/umount:
     post:
       tags:
@@ -5297,7 +5417,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_fuse_umount_0'
+              $ref: '#/components/schemas/gluster_fuse_umount'
   /gluster/localevents/add_jwt_secret:
     post:
       tags:
@@ -5329,7 +5449,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_localevents_add_jwt_secret_0'
+              $ref: '#/components/schemas/gluster_localevents_add_jwt_secret'
   /gluster/localevents/get_set_jwt_secret:
     get:
       tags:
@@ -5397,7 +5517,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_peer_create_0'
+              $ref: '#/components/schemas/gluster_peer_create'
   /gluster/peer/id/{id}:
     delete:
       tags:
@@ -5480,7 +5600,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_peer_status_0'
+              $ref: '#/components/schemas/gluster_peer_status'
   /gluster/volume:
     get:
       tags:
@@ -5539,7 +5659,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_create_0'
+              $ref: '#/components/schemas/gluster_volume_create'
   /gluster/volume/id/{id}:
     delete:
       tags:
@@ -5612,7 +5732,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_info_0'
+              $ref: '#/components/schemas/gluster_volume_info'
   /gluster/volume/list:
     get:
       tags:
@@ -5646,7 +5766,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_optreset_0'
+              $ref: '#/components/schemas/gluster_volume_optreset'
   /gluster/volume/optset:
     post:
       tags:
@@ -5668,7 +5788,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_optset_0'
+              $ref: '#/components/schemas/gluster_volume_optset'
   /gluster/volume/quota:
     post:
       tags:
@@ -5688,7 +5808,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_quota_0'
+              $ref: '#/components/schemas/gluster_volume_quota'
   /gluster/volume/restart:
     post:
       tags:
@@ -5708,7 +5828,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_restart_0'
+              $ref: '#/components/schemas/gluster_volume_restart'
   /gluster/volume/start:
     post:
       tags:
@@ -5728,7 +5848,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_start_0'
+              $ref: '#/components/schemas/gluster_volume_start'
   /gluster/volume/status:
     post:
       tags:
@@ -5748,7 +5868,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_status_0'
+              $ref: '#/components/schemas/gluster_volume_status'
   /gluster/volume/stop:
     post:
       tags:
@@ -5768,7 +5888,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/gluster_volume_stop_0'
+              $ref: '#/components/schemas/gluster_volume_stop'
   /group:
     get:
       tags:
@@ -5836,7 +5956,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/group_create_0'
+              $ref: '#/components/schemas/group_create'
   /group/id/{id}:
     delete:
       tags:
@@ -5856,6 +5976,11 @@ paths:
         Delete group `id`.
 
         The `delete_users` option deletes all users that have this group as their primary group.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/group_delete_by_id'
     get:
       tags:
         - group
@@ -5899,6 +6024,11 @@ paths:
           schema:
             type: integer
       description: Update attributes of an existing group.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/group_update_by_id'
   /group/get_group_obj:
     post:
       tags:
@@ -5916,7 +6046,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/group_get_group_obj_0'
+              $ref: '#/components/schemas/group_get_group_obj'
   /group/get_instance:
     post:
       tags:
@@ -6095,7 +6225,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/idmap_create_0'
+              $ref: '#/components/schemas/idmap_create'
   /idmap/id/{id}:
     delete:
       tags:
@@ -6145,6 +6275,11 @@ paths:
           schema:
             type: integer
       description: Update a domain by id.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/idmap_update_by_id'
   /idmap/backend_choices:
     get:
       tags:
@@ -6216,7 +6351,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/idmap_options_choices_0'
+              $ref: '#/components/schemas/idmap_options_choices'
   /initshutdownscript:
     get:
       tags:
@@ -6277,7 +6412,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/initshutdownscript_create_0'
+              $ref: '#/components/schemas/initshutdownscript_create'
   /initshutdownscript/id/{id}:
     delete:
       tags:
@@ -6324,6 +6459,11 @@ paths:
           schema:
             type: integer
       description: Update initshutdown script task of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/initshutdownscript_update_by_id'
   /initshutdownscript/get_instance:
     post:
       tags:
@@ -6401,7 +6541,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_create_0'
+              $ref: '#/components/schemas/interface_create'
   /interface/id/{id}:
     delete:
       tags:
@@ -6453,6 +6593,11 @@ paths:
       description: |+
         Update Interface of `id`.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/interface_update_by_id'
   /interface/bridge_members_choices:
     post:
       tags:
@@ -6472,7 +6617,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_bridge_members_choices_0'
+              $ref: '#/components/schemas/interface_bridge_members_choices'
   /interface/cancel_rollback:
     get:
       tags:
@@ -6538,7 +6683,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_choices_0'
+              $ref: '#/components/schemas/interface_choices'
   /interface/commit:
     post:
       tags:
@@ -6560,7 +6705,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_commit_0'
+              $ref: '#/components/schemas/interface_commit'
   /interface/default_route_will_be_removed:
     get:
       tags:
@@ -6645,7 +6790,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_ip_in_use_0'
+              $ref: '#/components/schemas/interface_ip_in_use'
   /interface/lacpdu_rate_choices:
     get:
       tags:
@@ -6676,7 +6821,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_lag_ports_choices_0'
+              $ref: '#/components/schemas/interface_lag_ports_choices'
   /interface/rollback:
     get:
       tags:
@@ -6751,7 +6896,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_save_default_route_0'
+              $ref: '#/components/schemas/interface_save_default_route'
   /interface/services_restarted_on_sync:
     get:
       tags:
@@ -6814,7 +6959,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_capabilities_get_0'
+              $ref: '#/components/schemas/interface_capabilities_get'
   /interface/capabilities/set:
     post:
       tags:
@@ -6836,7 +6981,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/interface_capabilities_set_0'
+              $ref: '#/components/schemas/interface_capabilities_set'
   /ipmi:
     get:
       tags:
@@ -6913,6 +7058,11 @@ paths:
         `password` is a password to be assigned to channel number `id`
         `dhcp` is a boolean. If False, `ipaddress`, `netmask` and `gateway` must be set.
         `vlan` is an integer representing the vlan tag number.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ipmi_update_by_id'
   /ipmi/channels:
     get:
       tags:
@@ -6975,7 +7125,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ipmi_identify_0'
+              $ref: '#/components/schemas/ipmi_identify'
   /ipmi/is_loaded:
     get:
       tags:
@@ -7074,7 +7224,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_auth_create_0'
+              $ref: '#/components/schemas/iscsi_auth_create'
   /iscsi/auth/id/{id}:
     delete:
       tags:
@@ -7121,6 +7271,11 @@ paths:
           schema:
             type: integer
       description: Update iSCSI Authorized Access of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_auth_update_by_id'
   /iscsi/auth/get_instance:
     post:
       tags:
@@ -7198,7 +7353,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_extent_create_0'
+              $ref: '#/components/schemas/iscsi_extent_create'
   /iscsi/extent/id/{id}:
     delete:
       tags:
@@ -7218,6 +7373,11 @@ paths:
         Delete iSCSI Extent of `id`.
 
         If `id` iSCSI Extent's `type` was configured to FILE, `remove` can be set to remove the configured file.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_extent_delete_by_id'
     get:
       tags:
         - iscsi.extent
@@ -7248,6 +7408,11 @@ paths:
           schema:
             type: integer
       description: Update iSCSI Extent of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_extent_update_by_id'
   /iscsi/extent/disk_choices:
     get:
       tags:
@@ -7305,7 +7470,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_global_update_0'
+              $ref: '#/components/schemas/iscsi_global_update'
   /iscsi/global/alua_enabled:
     get:
       tags:
@@ -7413,7 +7578,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_host_create_0'
+              $ref: '#/components/schemas/iscsi_host_create'
   /iscsi/host/id/{id}:
     delete:
       tags:
@@ -7460,6 +7625,11 @@ paths:
           schema:
             type: integer
       description: Update iSCSI host `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_host_update_by_id'
   /iscsi/host/get_initiators:
     post:
       tags:
@@ -7475,7 +7645,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_host_get_initiators_0'
+              $ref: '#/components/schemas/iscsi_host_get_initiators'
   /iscsi/host/get_instance:
     post:
       tags:
@@ -7510,7 +7680,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_host_get_targets_0'
+              $ref: '#/components/schemas/iscsi_host_get_targets'
   /iscsi/host/set_initiators:
     post:
       tags:
@@ -7594,7 +7764,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_initiator_create_0'
+              $ref: '#/components/schemas/iscsi_initiator_create'
   /iscsi/initiator/id/{id}:
     delete:
       tags:
@@ -7641,6 +7811,11 @@ paths:
           schema:
             type: integer
       description: Update iSCSI initiator of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_initiator_update_by_id'
   /iscsi/initiator/get_instance:
     post:
       tags:
@@ -7708,7 +7883,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_portal_create_0'
+              $ref: '#/components/schemas/iscsi_portal_create'
   /iscsi/portal/id/{id}:
     delete:
       tags:
@@ -7755,6 +7930,11 @@ paths:
           schema:
             type: integer
       description: Update iSCSI Portal `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_portal_update_by_id'
   /iscsi/portal/get_instance:
     post:
       tags:
@@ -7838,7 +8018,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_target_create_0'
+              $ref: '#/components/schemas/iscsi_target_create'
   /iscsi/target/id/{id}:
     delete:
       tags:
@@ -7858,6 +8038,11 @@ paths:
         Delete iSCSI Target of `id`.
 
         Deleting an iSCSI Target makes sure we delete all Associated Targets which use `id` iSCSI Target.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_target_delete_by_id'
     get:
       tags:
         - iscsi.target
@@ -7888,6 +8073,11 @@ paths:
           schema:
             type: integer
       description: Update iSCSI Target of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_target_update_by_id'
   /iscsi/target/get_instance:
     post:
       tags:
@@ -7955,7 +8145,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/iscsi_targetextent_create_0'
+              $ref: '#/components/schemas/iscsi_targetextent_create'
   /iscsi/targetextent/id/{id}:
     delete:
       tags:
@@ -7972,6 +8162,11 @@ paths:
           schema:
             type: integer
       description: Delete Associated Target of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_targetextent_delete_by_id'
     get:
       tags:
         - iscsi.targetextent
@@ -8002,6 +8197,11 @@ paths:
           schema:
             type: integer
       description: Update Associated Target of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iscsi_targetextent_update_by_id'
   /iscsi/targetextent/get_instance:
     post:
       tags:
@@ -8049,7 +8249,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/kerberos_update_0'
+              $ref: '#/components/schemas/kerberos_update'
   /kerberos/keytab:
     get:
       tags:
@@ -8100,7 +8300,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/kerberos_keytab_create_0'
+              $ref: '#/components/schemas/kerberos_keytab_create'
   /kerberos/keytab/id/{id}:
     delete:
       tags:
@@ -8149,6 +8349,11 @@ paths:
           schema:
             type: integer
       description: Update kerberos keytab by id.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/kerberos_keytab_update_by_id'
   /kerberos/keytab/get_instance:
     post:
       tags:
@@ -8198,7 +8403,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/kerberos_keytab_upload_keytab_0'
+              $ref: '#/components/schemas/kerberos_keytab_upload_keytab'
   /kerberos/realm:
     get:
       tags:
@@ -8254,7 +8459,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/kerberos_realm_create_0'
+              $ref: '#/components/schemas/kerberos_realm_create'
   /kerberos/realm/id/{id}:
     delete:
       tags:
@@ -8304,6 +8509,11 @@ paths:
         Update a kerberos realm by id. This will be automatically populated during the
         domain join process in an Active Directory environment. Kerberos realm names
         are case-sensitive, but convention is to only use upper-case.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/kerberos_realm_update_by_id'
   /kerberos/realm/get_instance:
     post:
       tags:
@@ -8390,7 +8600,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/keychaincredential_create_0'
+              $ref: '#/components/schemas/keychaincredential_create'
   /keychaincredential/id/{id}:
     delete:
       tags:
@@ -8409,6 +8619,11 @@ paths:
       description: |+
         Delete Keychain Credential with specific `id`
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/keychaincredential_delete_by_id'
     get:
       tags:
         - keychaincredential
@@ -8447,6 +8662,11 @@ paths:
 
         See the documentation for `create` method for information on payload contents
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/keychaincredential_update_by_id'
   /keychaincredential/generate_ssh_key_pair:
     get:
       tags:
@@ -8500,7 +8720,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/keychaincredential_remote_ssh_host_key_scan_0'
+              $ref: '#/components/schemas/keychaincredential_remote_ssh_host_key_scan'
   /keychaincredential/remote_ssh_semiautomatic_setup:
     post:
       tags:
@@ -8523,7 +8743,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/keychaincredential_remote_ssh_semiautomatic_setup_0'
+              $ref: '#/components/schemas/keychaincredential_remote_ssh_semiautomatic_setup'
   /keychaincredential/setup_ssh_connection:
     post:
       tags:
@@ -8546,7 +8766,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/keychaincredential_setup_ssh_connection_0'
+              $ref: '#/components/schemas/keychaincredential_setup_ssh_connection'
   /keychaincredential/used_by:
     post:
       tags:
@@ -8562,7 +8782,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/keychaincredential_used_by_0'
+              $ref: '#/components/schemas/keychaincredential_used_by'
   /kmip:
     get:
       tags:
@@ -8613,7 +8833,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/kmip_update_0'
+              $ref: '#/components/schemas/kmip_update'
   /kmip/clear_sync_pending_keys:
     get:
       tags:
@@ -8726,7 +8946,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/kubernetes_update_0'
+              $ref: '#/components/schemas/kubernetes_update'
   /kubernetes/backup_chart_releases:
     post:
       tags:
@@ -8746,7 +8966,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/kubernetes_backup_chart_releases_0'
+              $ref: '#/components/schemas/kubernetes_backup_chart_releases'
   /kubernetes/bindip_choices:
     get:
       tags:
@@ -8773,7 +8993,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/kubernetes_delete_backup_0'
+              $ref: '#/components/schemas/kubernetes_delete_backup'
   /kubernetes/events:
     get:
       tags:
@@ -8913,7 +9133,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ldap_update_0'
+              $ref: '#/components/schemas/ldap_update'
   /ldap/get_state:
     get:
       tags:
@@ -8984,7 +9204,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/mail_update_0'
+              $ref: '#/components/schemas/mail_update'
   /mail/send:
     post:
       tags:
@@ -9079,7 +9299,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/network_configuration_update_0'
+              $ref: '#/components/schemas/network_configuration_update'
   /network/configuration/activity_choices:
     get:
       tags:
@@ -9154,7 +9374,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/nfs_update_0'
+              $ref: '#/components/schemas/nfs_update'
   /nfs/add_principal:
     post:
       tags:
@@ -9175,7 +9395,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/nfs_add_principal_0'
+              $ref: '#/components/schemas/nfs_add_principal'
   /nfs/bindip_choices:
     get:
       tags:
@@ -9302,7 +9522,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/openvpn_client_update_0'
+              $ref: '#/components/schemas/openvpn_client_update'
   /openvpn/client/authentication_algorithm_choices:
     get:
       tags:
@@ -9354,7 +9574,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/openvpn_server_update_0'
+              $ref: '#/components/schemas/openvpn_server_update'
   /openvpn/server/authentication_algorithm_choices:
     get:
       tags:
@@ -9494,7 +9714,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_create_0'
+              $ref: '#/components/schemas/pool_create'
   /pool/id/{id}:
     get:
       tags:
@@ -9530,6 +9750,11 @@ paths:
 
         The `type` of `data` must be the same of existing vdevs.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_update_by_id'
   /pool/attach:
     post:
       tags:
@@ -9572,6 +9797,11 @@ paths:
 
         Responsible for telling the user whether there is a related
         share, asking for confirmation.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_attachments_by_id'
   /pool/id/{id}/detach:
     post:
       tags:
@@ -9592,6 +9822,11 @@ paths:
 
         `label` is the vdev guid or device name.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_detach_by_id'
   /pool/id/{id}/expand:
     post:
       tags:
@@ -9608,6 +9843,11 @@ paths:
           schema:
             type: integer
       description: Expand pool to fit all available disk space.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_expand_by_id'
   /pool/id/{id}/export:
     post:
       tags:
@@ -9630,6 +9870,11 @@ paths:
         `restart_services` will restart services that have open files on given pool.
         `destroy` will also PERMANENTLY destroy the pool/data.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_export_by_id'
   /pool/filesystem_choices:
     post:
       tags:
@@ -9650,7 +9895,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_filesystem_choices_0'
+              $ref: '#/components/schemas/pool_filesystem_choices'
   /pool/id/{id}/get_disks:
     post:
       tags:
@@ -9669,6 +9914,11 @@ paths:
       description: |-
         Get all disks in use by pools.
         If `id` is provided only the disks from the given pool `id` will be returned.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_get_disks_by_id'
   /pool/get_instance:
     post:
       tags:
@@ -9703,7 +9953,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_get_instance_by_name_0'
+              $ref: '#/components/schemas/pool_get_instance_by_name'
   /pool/import_disk:
     post:
       tags:
@@ -9739,7 +9989,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_import_disk_autodetect_fs_type_0'
+              $ref: '#/components/schemas/pool_import_disk_autodetect_fs_type'
   /pool/import_disk_msdosfs_locales:
     get:
       tags:
@@ -9792,7 +10042,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_import_pool_0'
+              $ref: '#/components/schemas/pool_import_pool'
   /pool/id/{id}/is_upgraded:
     post:
       tags:
@@ -9812,6 +10062,11 @@ paths:
         Returns whether or not the pool of `id` is on the latest version and with all feature
         flags enabled.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_is_upgraded_by_id'
   /pool/id/{id}/offline:
     post:
       tags:
@@ -9832,6 +10087,11 @@ paths:
 
         `label` is the vdev guid or device name.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_offline_by_id'
   /pool/id/{id}/online:
     post:
       tags:
@@ -9852,6 +10112,11 @@ paths:
 
         `label` is the vdev guid or device name.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_online_by_id'
   /pool/id/{id}/processes:
     post:
       tags:
@@ -9868,6 +10133,11 @@ paths:
           schema:
             type: integer
       description: Returns a list of running processes using this pool.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_processes_by_id'
   /pool/id/{id}/remove:
     post:
       tags:
@@ -9894,6 +10164,11 @@ paths:
             EZFS_NODEVICE(2017): no such device in pool
             EZFS_NOREPLICAS(2019): no valid replicas
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_remove_by_id'
   /pool/id/{id}/replace:
     post:
       tags:
@@ -9917,6 +10192,11 @@ paths:
         If `preserve_settings` is true, then settings (power management, S.M.A.R.T., etc.) of a disk being replaced
         will be applied to a new disk.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_replace_by_id'
   /pool/id/{id}/scrub:
     post:
       tags:
@@ -9937,6 +10217,11 @@ paths:
 
         `action` can be either of "START", "STOP" or "PAUSE".
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_scrub_by_id'
   /pool/id/{id}/upgrade:
     post:
       tags:
@@ -9955,6 +10240,11 @@ paths:
       description: |+
         Upgrade pool of `id` to latest version with all feature flags.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_upgrade_by_id'
   /pool/dataset:
     get:
       tags:
@@ -10051,7 +10341,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_dataset_create_0'
+              $ref: '#/components/schemas/pool_dataset_create'
   /pool/dataset/id/{id}:
     delete:
       tags:
@@ -10073,6 +10363,11 @@ paths:
         `recursive` will also delete/destroy all children datasets.
         `force` will force delete busy datasets.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_delete_by_id'
     get:
       tags:
         - pool.dataset
@@ -10134,6 +10429,11 @@ paths:
       description: |+
         Updates a dataset/zvol `id`.
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_update_by_id'
   /pool/dataset/id/{id}/attachments:
     post:
       tags:
@@ -10163,6 +10463,11 @@ paths:
             "attachments": ["/mnt/tank/work"]
           }
         ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_attachments_by_id'
   /pool/dataset/change_key:
     post:
       tags:
@@ -10370,7 +10675,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_dataset_export_keys_0'
+              $ref: '#/components/schemas/pool_dataset_export_keys'
   /pool/dataset/get_instance:
     post:
       tags:
@@ -10434,6 +10739,11 @@ paths:
 
         Note: SMB client requests to set a quota granting no space will result
         in an on-disk quota of 1 KiB.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_get_quota_by_id'
   /pool/dataset/inherit_parent_encryption_properties:
     post:
       tags:
@@ -10451,7 +10761,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_dataset_inherit_parent_encryption_properties_0'
+              $ref: '#/components/schemas/pool_dataset_inherit_parent_encryption_properties'
   /pool/dataset/lock:
     post:
       tags:
@@ -10535,6 +10845,11 @@ paths:
         `traverse` - permit recursive job to traverse filesystem boundaries
         (child datasets).
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_permission_by_id'
   /pool/dataset/id/{id}/processes:
     post:
       tags:
@@ -10567,6 +10882,11 @@ paths:
             "cmdline": "/usr/local/bin/minio -C /usr/local/etc/minio server --address=0.0.0.0:9000 --quiet /mnt/tank/wk"
           }
         ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_processes_by_id'
   /pool/dataset/id/{id}/promote:
     post:
       tags:
@@ -10583,6 +10903,11 @@ paths:
           schema:
             type: string
       description: Promote the cloned dataset `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_promote_by_id'
   /pool/dataset/recommended_zvol_blocksize:
     post:
       tags:
@@ -10600,7 +10925,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_dataset_recommended_zvol_blocksize_0'
+              $ref: '#/components/schemas/pool_dataset_recommended_zvol_blocksize'
   /pool/dataset/recordsize_choices:
     get:
       tags:
@@ -10658,6 +10983,11 @@ paths:
 
         `quota_value`: the quota size in bytes. Setting a value of `0` removes
         the user or group quota.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_set_quota_by_id'
   /pool/dataset/snapshot_count:
     post:
       tags:
@@ -10673,7 +11003,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_dataset_snapshot_count_0'
+              $ref: '#/components/schemas/pool_dataset_snapshot_count'
   /pool/dataset/unlock:
     post:
       tags:
@@ -10735,7 +11065,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_dataset_unlock_services_restart_choices_0'
+              $ref: '#/components/schemas/pool_dataset_unlock_services_restart_choices'
   /pool/dataset/userprop:
     get:
       tags:
@@ -10784,7 +11114,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_dataset_userprop_create_0'
+              $ref: '#/components/schemas/pool_dataset_userprop_create'
   /pool/dataset/userprop/id/{id}:
     delete:
       tags:
@@ -10801,6 +11131,11 @@ paths:
           schema:
             type: string
       description: Delete user property `dataset_user_prop_delete.name` for `id` dataset.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_userprop_delete_by_id'
     get:
       tags:
         - pool.dataset.userprop
@@ -10834,6 +11169,11 @@ paths:
           schema:
             type: string
       description: Update `dataset_user_prop_update.name` user property for `id` dataset.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_dataset_userprop_update_by_id'
   /pool/dataset/userprop/get_instance:
     post:
       tags:
@@ -10886,7 +11226,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_resilver_update_0'
+              $ref: '#/components/schemas/pool_resilver_update'
   /pool/scrub:
     get:
       tags:
@@ -10937,7 +11277,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_scrub_create_0'
+              $ref: '#/components/schemas/pool_scrub_create'
   /pool/scrub/id/{id}:
     delete:
       tags:
@@ -10984,6 +11324,11 @@ paths:
           schema:
             type: integer
       description: Update scrub task of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_scrub_update_by_id'
   /pool/scrub/get_instance:
     post:
       tags:
@@ -11092,7 +11437,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_snapshottask_create_0'
+              $ref: '#/components/schemas/pool_snapshottask_create'
   /pool/snapshottask/id/{id}:
     delete:
       tags:
@@ -11111,6 +11456,11 @@ paths:
       description: |+
         Delete a Periodic Snapshot Task with specific `id`
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_snapshottask_delete_by_id'
     get:
       tags:
         - pool.snapshottask
@@ -11145,6 +11495,11 @@ paths:
 
         See the documentation for `create` method for information on payload contents
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_snapshottask_update_by_id'
   /pool/snapshottask/id/{id}/delete_will_change_retention_for:
     post:
       tags:
@@ -11161,6 +11516,11 @@ paths:
           schema:
             type: integer
       description: Returns a list of snapshots which will change the retention if periodic snapshot task `id` is deleted.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_snapshottask_delete_will_change_retention_for_by_id'
   /pool/snapshottask/foreseen_count:
     post:
       tags:
@@ -11178,7 +11538,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/pool_snapshottask_foreseen_count_0'
+              $ref: '#/components/schemas/pool_snapshottask_foreseen_count'
   /pool/snapshottask/get_instance:
     post:
       tags:
@@ -11236,6 +11596,11 @@ paths:
           schema:
             type: integer
       description: Execute a Periodic Snapshot Task of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_snapshottask_run_by_id'
   /pool/snapshottask/id/{id}/update_will_change_retention_for:
     post:
       tags:
@@ -11254,6 +11619,11 @@ paths:
       description: |-
         Returns a list of snapshots which will change the retention if periodic snapshot task `id` is updated
         with `data`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pool_snapshottask_update_will_change_retention_for_by_id'
   /privilege:
     get:
       tags:
@@ -11310,7 +11680,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/privilege_create_0'
+              $ref: '#/components/schemas/privilege_create'
   /privilege/id/{id}:
     delete:
       tags:
@@ -11357,6 +11727,11 @@ paths:
           schema:
             type: integer
       description: Update the privilege `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/privilege_update_by_id'
   /privilege/get_instance:
     post:
       tags:
@@ -11469,7 +11844,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/replication_create_0'
+              $ref: '#/components/schemas/replication_create'
   /replication/id/{id}:
     delete:
       tags:
@@ -11522,6 +11897,11 @@ paths:
 
         See the documentation for `create` method for information on payload contents
 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/replication_update_by_id'
   /replication/count_eligible_manual_snapshots:
     post:
       tags:
@@ -11539,7 +11919,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/replication_count_eligible_manual_snapshots_0'
+              $ref: '#/components/schemas/replication_count_eligible_manual_snapshots'
   /replication/create_dataset:
     post:
       tags:
@@ -11626,6 +12006,11 @@ paths:
           schema:
             type: integer
       description: Create the opposite of replication task `id` (PULL if it was PUSH and vice versa).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/replication_restore_by_id'
   /replication/id/{id}/run:
     post:
       tags:
@@ -11642,6 +12027,11 @@ paths:
           schema:
             type: integer
       description: Run Replication Task of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/replication_run_by_id'
   /replication/run_onetime:
     post:
       tags:
@@ -11660,7 +12050,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/replication_run_onetime_0'
+              $ref: '#/components/schemas/replication_run_onetime'
   /replication/target_unmatched_snapshots:
     post:
       tags:
@@ -11704,7 +12094,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/replication_config_update_0'
+              $ref: '#/components/schemas/replication_config_update'
   /reporting:
     get:
       tags:
@@ -11742,7 +12132,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/reporting_update_0'
+              $ref: '#/components/schemas/reporting_update'
   /reporting/clear:
     get:
       tags:
@@ -11829,7 +12219,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/route_ipv4gw_reachable_0'
+              $ref: '#/components/schemas/route_ipv4gw_reachable'
   /route/system_routes:
     get:
       tags:
@@ -11892,7 +12282,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/rsyncd_update_0'
+              $ref: '#/components/schemas/rsyncd_update'
   /rsyncmod:
     get:
       tags:
@@ -11955,7 +12345,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/rsyncmod_create_0'
+              $ref: '#/components/schemas/rsyncmod_create'
   /rsyncmod/id/{id}:
     delete:
       tags:
@@ -12002,6 +12392,11 @@ paths:
           schema:
             type: integer
       description: Update Rsyncmod module of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/rsyncmod_update_by_id'
   /rsyncmod/get_instance:
     post:
       tags:
@@ -12096,7 +12491,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/rsynctask_create_0'
+              $ref: '#/components/schemas/rsynctask_create'
   /rsynctask/id/{id}:
     delete:
       tags:
@@ -12143,6 +12538,11 @@ paths:
           schema:
             type: integer
       description: Update Rsync Task of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/rsynctask_update_by_id'
   /rsynctask/get_instance:
     post:
       tags:
@@ -12181,6 +12581,11 @@ paths:
         Job to run rsync task of `id`.
 
         Output is saved to job log excerpt (not syslog).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/rsynctask_run_by_id'
   /s3:
     get:
       tags:
@@ -12216,7 +12621,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/s3_update_0'
+              $ref: '#/components/schemas/s3_update'
   /s3/bindip_choices:
     get:
       tags:
@@ -12331,6 +12736,11 @@ paths:
 
         Currently it only accepts `enable` option which means whether the
         service should start on boot.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/service_update_by_id'
   /service/get_instance:
     post:
       tags:
@@ -12417,7 +12827,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/service_started_0'
+              $ref: '#/components/schemas/service_started'
   /service/started_or_enabled:
     post:
       tags:
@@ -12433,7 +12843,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/service_started_or_enabled_0'
+              $ref: '#/components/schemas/service_started_or_enabled'
   /service/stop:
     post:
       tags:
@@ -12525,7 +12935,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/sharing_nfs_create_0'
+              $ref: '#/components/schemas/sharing_nfs_create'
   /sharing/nfs/id/{id}:
     delete:
       tags:
@@ -12572,6 +12982,11 @@ paths:
           schema:
             type: integer
       description: Update NFS Share of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sharing_nfs_update_by_id'
   /sharing/nfs/get_instance:
     post:
       tags:
@@ -12669,7 +13084,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/sharing_smb_create_0'
+              $ref: '#/components/schemas/sharing_smb_create'
   /sharing/smb/id/{id}:
     delete:
       tags:
@@ -12722,6 +13137,11 @@ paths:
           schema:
             type: integer
       description: Update SMB Share of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sharing_smb_update_by_id'
   /sharing/smb/get_instance:
     post:
       tags:
@@ -12805,7 +13225,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/sharing_webdav_create_0'
+              $ref: '#/components/schemas/sharing_webdav_create'
   /sharing/webdav/id/{id}:
     delete:
       tags:
@@ -12852,6 +13272,11 @@ paths:
           schema:
             type: integer
       description: Update Webdav Share of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sharing_webdav_update_by_id'
   /sharing/webdav/get_instance:
     post:
       tags:
@@ -12904,7 +13329,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/smart_update_0'
+              $ref: '#/components/schemas/smart_update'
   /smart/test:
     get:
       tags:
@@ -12958,7 +13383,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/smart_test_create_0'
+              $ref: '#/components/schemas/smart_test_create'
   /smart/test/id/{id}:
     delete:
       tags:
@@ -13005,6 +13430,11 @@ paths:
           schema:
             type: integer
       description: Update SMART Test Task of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/smart_test_update_by_id'
   /smart/test/disk_choices:
     post:
       tags:
@@ -13023,7 +13453,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/smart_test_disk_choices_0'
+              $ref: '#/components/schemas/smart_test_disk_choices'
   /smart/test/get_instance:
     post:
       tags:
@@ -13061,7 +13491,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/smart_test_manual_test_0'
+              $ref: '#/components/schemas/smart_test_manual_test'
   /smart/test/query_for_disk:
     post:
       tags:
@@ -13077,7 +13507,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/smart_test_query_for_disk_0'
+              $ref: '#/components/schemas/smart_test_query_for_disk'
   /smart/test/results:
     get:
       tags:
@@ -13141,7 +13571,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/smb_update_0'
+              $ref: '#/components/schemas/smb_update'
   /smb/bindip_choices:
     get:
       tags:
@@ -13212,7 +13642,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/smb_get_remote_acl_0'
+              $ref: '#/components/schemas/smb_get_remote_acl'
   /smb/status:
     post:
       tags:
@@ -13322,7 +13752,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/smb_sharesec_create_0'
+              $ref: '#/components/schemas/smb_sharesec_create'
   /smb/sharesec/id/{id}:
     delete:
       tags:
@@ -13379,6 +13809,11 @@ paths:
       description: |-
         Update the ACL on the share specified by the numerical index `id`. Will write changes
         to both /var/db/system/samba4/share_info.tdb and the configuration file.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/smb_sharesec_update_by_id'
   /smb/sharesec/get_instance:
     post:
       tags:
@@ -13470,7 +13905,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/snmp_update_0'
+              $ref: '#/components/schemas/snmp_update'
   /ssh:
     get:
       tags:
@@ -13500,7 +13935,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ssh_update_0'
+              $ref: '#/components/schemas/ssh_update'
   /ssh/bindiface_choices:
     get:
       tags:
@@ -13562,7 +13997,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/staticroute_create_0'
+              $ref: '#/components/schemas/staticroute_create'
   /staticroute/id/{id}:
     delete:
       tags:
@@ -13609,6 +14044,11 @@ paths:
           schema:
             type: integer
       description: Update Static Route of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/staticroute_update_by_id'
   /staticroute/get_instance:
     post:
       tags:
@@ -13696,7 +14136,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/support_update_0'
+              $ref: '#/components/schemas/support_update'
   /support/attach_ticket:
     post:
       tags:
@@ -13715,7 +14155,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/support_attach_ticket_0'
+              $ref: '#/components/schemas/support_attach_ticket'
   /support/attach_ticket_max_size:
     get:
       tags:
@@ -13744,7 +14184,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/support_fetch_categories_0'
+              $ref: '#/components/schemas/support_fetch_categories'
   /support/fields:
     get:
       tags:
@@ -13799,7 +14239,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/support_new_ticket_0'
+              $ref: '#/components/schemas/support_new_ticket'
   /system/boot_id:
     get:
       tags:
@@ -13857,7 +14297,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_feature_enabled_0'
+              $ref: '#/components/schemas/system_feature_enabled'
   /system/host_id:
     get:
       tags:
@@ -13925,7 +14365,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_license_update_0'
+              $ref: '#/components/schemas/system_license_update'
   /system/product_name:
     get:
       tags:
@@ -13981,7 +14421,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_reboot_0'
+              $ref: '#/components/schemas/system_reboot'
   /system/shutdown:
     post:
       tags:
@@ -14000,7 +14440,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_shutdown_0'
+              $ref: '#/components/schemas/system_shutdown'
   /system/state:
     get:
       tags:
@@ -14066,7 +14506,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_advanced_update_0'
+              $ref: '#/components/schemas/system_advanced_update'
   /system/advanced/sed_global_password:
     get:
       tags:
@@ -14126,7 +14566,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_advanced_update_gpu_pci_ids_0'
+              $ref: '#/components/schemas/system_advanced_update_gpu_pci_ids'
   /system/general:
     get:
       tags:
@@ -14177,7 +14617,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_general_update_0'
+              $ref: '#/components/schemas/system_general_update'
   /system/general/checkin:
     get:
       tags:
@@ -14312,7 +14752,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_general_ui_restart_0'
+              $ref: '#/components/schemas/system_general_ui_restart'
     post:
       tags:
         - system.general
@@ -14330,7 +14770,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_general_ui_restart_0'
+              $ref: '#/components/schemas/system_general_ui_restart'
   /system/general/ui_v6address_choices:
     get:
       tags:
@@ -14405,7 +14845,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/system_ntpserver_create_0'
+              $ref: '#/components/schemas/system_ntpserver_create'
   /system/ntpserver/id/{id}:
     delete:
       tags:
@@ -14452,6 +14892,11 @@ paths:
           schema:
             type: integer
       description: Update NTP server of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/system_ntpserver_update_by_id'
   /system/ntpserver/get_instance:
     post:
       tags:
@@ -14502,7 +14947,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/systemdataset_update_0'
+              $ref: '#/components/schemas/systemdataset_update'
   /systemdataset/pool_choices:
     post:
       tags:
@@ -14518,7 +14963,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/systemdataset_pool_choices_0'
+              $ref: '#/components/schemas/systemdataset_pool_choices'
   /tftp:
     get:
       tags:
@@ -14550,7 +14995,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/tftp_update_0'
+              $ref: '#/components/schemas/tftp_update'
   /tftp/host_choices:
     get:
       tags:
@@ -14590,7 +15035,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/truecommand_update_0'
+              $ref: '#/components/schemas/truecommand_update'
   /truenas/accept_eula:
     get:
       tags:
@@ -14688,7 +15133,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/truenas_update_customer_information_0'
+              $ref: '#/components/schemas/truenas_update_customer_information'
   /tunable:
     get:
       tags:
@@ -14741,7 +15186,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/tunable_create_0'
+              $ref: '#/components/schemas/tunable_create'
   /tunable/id/{id}:
     delete:
       tags:
@@ -14788,6 +15233,11 @@ paths:
           schema:
             type: integer
       description: Update Tunable of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/tunable_update_by_id'
   /tunable/get_instance:
     post:
       tags:
@@ -14841,7 +15291,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/update_check_available_0'
+              $ref: '#/components/schemas/update_check_available'
   /update/download:
     get:
       tags:
@@ -14873,7 +15323,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/update_file_0'
+              $ref: '#/components/schemas/update_file'
   /update/get_auto_download:
     get:
       tags:
@@ -14907,7 +15357,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/update_get_pending_0'
+              $ref: '#/components/schemas/update_get_pending'
   /update/get_trains:
     get:
       tags:
@@ -14955,7 +15405,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/update_set_auto_download_0'
+              $ref: '#/components/schemas/update_set_auto_download'
   /update/set_train:
     post:
       tags:
@@ -14971,7 +15421,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/update_set_train_0'
+              $ref: '#/components/schemas/update_set_train'
   /update/update:
     post:
       tags:
@@ -14987,7 +15437,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/update_update_0'
+              $ref: '#/components/schemas/update_update'
   /ups:
     get:
       tags:
@@ -15024,7 +15474,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ups_update_0'
+              $ref: '#/components/schemas/ups_update'
   /ups/driver_choices:
     get:
       tags:
@@ -15120,7 +15570,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/user_create_0'
+              $ref: '#/components/schemas/user_create'
   /user/id/{id}:
     delete:
       tags:
@@ -15141,6 +15591,11 @@ paths:
 
         The `delete_group` option deletes the user primary group if it is not being used by
         any other user.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/user_delete_by_id'
     get:
       tags:
         - user
@@ -15185,6 +15640,11 @@ paths:
           schema:
             type: integer
       description: Update attributes of an existing user.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/user_update_by_id'
   /user/get_instance:
     post:
       tags:
@@ -15232,7 +15692,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/user_get_user_obj_0'
+              $ref: '#/components/schemas/user_get_user_obj'
   /user/has_local_administrator_set_up:
     get:
       tags:
@@ -15275,6 +15735,11 @@ paths:
           schema:
             type: integer
       description: Remove user general purpose `attributes` dictionary `key`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/user_pop_attribute_by_id'
   /user/id/{id}/set_attribute:
     post:
       tags:
@@ -15294,6 +15759,11 @@ paths:
         Set user general purpose `attributes` dictionary `key` to `value`.
 
         e.g. Setting key="foo" value="var" will result in {"attributes": {"foo": "bar"}}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/user_set_attribute_by_id'
   /user/shell_choices:
     post:
       tags:
@@ -15312,7 +15782,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/user_shell_choices_0'
+              $ref: '#/components/schemas/user_shell_choices'
   /vm:
     get:
       tags:
@@ -15390,7 +15860,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_create_0'
+              $ref: '#/components/schemas/vm_create'
   /vm/id/{id}:
     delete:
       tags:
@@ -15407,6 +15877,11 @@ paths:
           schema:
             type: integer
       description: Delete a VM.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_delete_by_id'
     get:
       tags:
         - vm
@@ -15448,6 +15923,11 @@ paths:
         2) Devices are updated in the `devices` list when they contain a valid `id` attribute that corresponds to
            an existing device.
         3) Devices that do not have an `id` attribute are created and attached to `id` VM.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_update_by_id'
   /vm/bootloader_options:
     get:
       tags:
@@ -15479,6 +15959,11 @@ paths:
 
         `name` is an optional parameter for the cloned VM.
         If not provided it will append the next number available to the VM name.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_clone_by_id'
   /vm/cpu_model_choices:
     get:
       tags:
@@ -15531,7 +16016,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_get_available_memory_0'
+              $ref: '#/components/schemas/vm_get_available_memory'
   /vm/get_console:
     post:
       tags:
@@ -15547,7 +16032,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_get_console_0'
+              $ref: '#/components/schemas/vm_get_console'
   /vm/get_display_devices:
     post:
       tags:
@@ -15565,7 +16050,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_get_display_devices_0'
+              $ref: '#/components/schemas/vm_get_display_devices'
   /vm/get_instance:
     post:
       tags:
@@ -15600,7 +16085,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_get_memory_usage_0'
+              $ref: '#/components/schemas/vm_get_memory_usage'
   /vm/get_vm_memory_info:
     post:
       tags:
@@ -15619,7 +16104,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_get_vm_memory_info_0'
+              $ref: '#/components/schemas/vm_get_vm_memory_info'
   /vm/get_vmemory_in_use:
     get:
       tags:
@@ -15670,7 +16155,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_log_file_path_0'
+              $ref: '#/components/schemas/vm_log_file_path'
   /vm/maximum_supported_vcpus:
     get:
       tags:
@@ -15712,6 +16197,11 @@ paths:
           schema:
             type: integer
       description: Poweroff a VM.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_poweroff_by_id'
   /vm/random_mac:
     get:
       tags:
@@ -15754,6 +16244,11 @@ paths:
           schema:
             type: integer
       description: Restart a VM.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_restart_by_id'
   /vm/id/{id}/resume:
     post:
       tags:
@@ -15770,6 +16265,11 @@ paths:
           schema:
             type: integer
       description: Resume suspended `id` VM.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_resume_by_id'
   /vm/id/{id}/start:
     post:
       tags:
@@ -15795,6 +16295,11 @@ paths:
         Error codes:
 
             ENOMEM(12): not enough free memory to run the VM without overcommit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_start_by_id'
   /vm/id/{id}/status:
     post:
       tags:
@@ -15816,6 +16321,11 @@ paths:
         Returns a dict:
             - state, RUNNING / STOPPED / SUSPENDED
             - pid, process id if RUNNING
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_status_by_id'
   /vm/id/{id}/stop:
     post:
       tags:
@@ -15840,6 +16350,11 @@ paths:
 
         `force_after_timeout` when supplied, it will initiate poweroff for the VM forcing it to exit if it has
         not already stopped within the specified `shutdown_timeout`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_stop_by_id'
   /vm/supports_virtualization:
     get:
       tags:
@@ -15867,6 +16382,11 @@ paths:
           schema:
             type: integer
       description: Suspend `id` VM.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_suspend_by_id'
   /vm/virtualization_details:
     get:
       tags:
@@ -15930,7 +16450,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_device_create_0'
+              $ref: '#/components/schemas/vm_device_create'
   /vm/device/id/{id}:
     delete:
       tags:
@@ -15947,6 +16467,11 @@ paths:
           schema:
             type: integer
       description: Delete a VM device of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_device_delete_by_id'
     get:
       tags:
         - vm.device
@@ -15980,6 +16505,11 @@ paths:
         Update a VM device of `id`.
 
         Pass `attributes.size` to resize a `dtype` `RAW` device. The raw file will be resized.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vm_device_update_by_id'
   /vm/device/bind_choices:
     get:
       tags:
@@ -16069,7 +16599,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_device_passthrough_device_0'
+              $ref: '#/components/schemas/vm_device_passthrough_device'
   /vm/device/passthrough_device_choices:
     get:
       tags:
@@ -16129,7 +16659,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vm_device_usb_passthrough_device_0'
+              $ref: '#/components/schemas/vm_device_usb_passthrough_device'
   /vmware:
     get:
       tags:
@@ -16183,7 +16713,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vmware_create_0'
+              $ref: '#/components/schemas/vmware_create'
   /vmware/id/{id}:
     delete:
       tags:
@@ -16230,6 +16760,11 @@ paths:
           schema:
             type: integer
       description: Update VMWare snapshot of `id`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vmware_update_by_id'
   /vmware/dataset_has_vms:
     post:
       tags:
@@ -16261,7 +16796,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vmware_get_datastores_0'
+              $ref: '#/components/schemas/vmware_get_datastores'
   /vmware/get_instance:
     post:
       tags:
@@ -16296,7 +16831,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vmware_get_virtual_machines_0'
+              $ref: '#/components/schemas/vmware_get_virtual_machines'
   /vmware/match_datastores_with_datasets:
     post:
       tags:
@@ -16316,7 +16851,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/vmware_match_datastores_with_datasets_0'
+              $ref: '#/components/schemas/vmware_match_datastores_with_datasets'
   /webdav:
     get:
       tags:
@@ -16356,7 +16891,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/webdav_update_0'
+              $ref: '#/components/schemas/webdav_update'
   /webdav/cert_choices:
     get:
       tags:
@@ -16419,7 +16954,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/webui_image_create_0'
+              $ref: '#/components/schemas/webui_image_create'
   /webui/image/id/{id}:
     delete:
       tags:
@@ -16524,7 +17059,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/zfs_snapshot_create_0'
+              $ref: '#/components/schemas/zfs_snapshot_create'
   /zfs/snapshot/id/{id}:
     delete:
       tags:
@@ -16544,6 +17079,11 @@ paths:
         Delete snapshot of name `id`.
 
         `options.defer` will defer the deletion of snapshot.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/zfs_snapshot_delete_by_id'
     get:
       tags:
         - zfs.snapshot
@@ -16583,6 +17123,11 @@ paths:
           schema:
             type: string
       description: ""
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/zfs_snapshot_update_by_id'
   /zfs/snapshot/clone:
     post:
       tags:
@@ -16602,7 +17147,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/zfs_snapshot_clone_0'
+              $ref: '#/components/schemas/zfs_snapshot_clone'
   /zfs/snapshot/get_instance:
     post:
       tags:
@@ -16684,7 +17229,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/zfs_snapshot_remove_0'
+              $ref: '#/components/schemas/zfs_snapshot_remove'
   /zfs/snapshot/rollback:
     post:
       tags:
@@ -16713,7 +17258,7 @@ paths:
             schema:
               $ref: '#/components/schemas/zfs_snapshot_rollback'
 servers:
-  - url: https://nas.local.geekspace.us/api/v2.0
+  - url: http://localhost/api/v2.0
 components:
   schemas:
     core_bulk_0:
@@ -16839,7 +17384,7 @@ components:
           $ref: '#/components/schemas/core_download_2'
         buffered:
           $ref: '#/components/schemas/core_download_3'
-    core_job_abort_0:
+    core_job_abort:
       type: integer
       _name_: id
       title: id
@@ -16871,11 +17416,11 @@ components:
           $ref: '#/components/schemas/core_job_update_0'
         job-update:
           $ref: '#/components/schemas/core_job_update_1'
-    core_job_wait_0:
+    core_job_wait:
       type: integer
       _name_: id
       title: id
-    core_ping_remote_0:
+    core_ping_remote:
       type: object
       properties:
         type:
@@ -16925,11 +17470,11 @@ components:
           $ref: '#/components/schemas/core_resize_shell_1'
         rows:
           $ref: '#/components/schemas/core_resize_shell_2'
-    core_set_debug_mode_0:
+    core_set_debug_mode:
       type: boolean
       _name_: debug_mode
       title: debug_mode
-    acme_dns_authenticator_create_0:
+    acme_dns_authenticator_create:
       type: object
       properties:
         authenticator:
@@ -16956,10 +17501,34 @@ components:
           type: string
       additionalProperties: false
       _name_: acme_dns_authenticator_create
-      title: acme_dns_authenticator_entry
+      title: acme_dns_authenticator_create
       default: {}
       _attrs_order_:
         - authenticator
+        - attributes
+        - name
+    acme_dns_authenticator_update_by_id:
+      type: object
+      properties:
+        attributes:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: attributes
+          title: attributes
+          description: Specific attributes of each `authenticator`
+          default: {}
+          _attrs_order_: []
+        name:
+          _name_: name
+          title: name
+          description: User defined name of authenticator
+          type: string
+      additionalProperties: false
+      _name_: dns_authenticator_update
+      title: dns_authenticator_update
+      default: {}
+      _attrs_order_:
         - attributes
         - name
     acme_dns_authenticator_get_instance_0:
@@ -17046,7 +17615,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -17066,9 +17635,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/acme_dns_authenticator_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/acme_dns_authenticator_get_instance_1'
-    activedirectory_update_0:
+    activedirectory_update:
       type: object
       properties:
         domainname:
@@ -17254,12 +17823,12 @@ components:
         - netbiosname_b
         - netbiosalias
         - enable
-    activedirectory_domain_info_0:
+    activedirectory_domain_info:
       _name_: domain
       title: domain
       default: ""
       type: string
-    activedirectory_leave_0:
+    activedirectory_leave:
       type: object
       properties:
         username:
@@ -17277,15 +17846,15 @@ components:
       _attrs_order_:
         - username
         - password
-    alert_dismiss_0:
+    alert_dismiss:
       _name_: uuid
       title: uuid
       type: string
-    alert_restore_0:
+    alert_restore:
       _name_: uuid
       title: uuid
       type: string
-    alertclasses_update_0:
+    alertclasses_update:
       type: object
       properties:
         classes:
@@ -17298,11 +17867,11 @@ components:
           _attrs_order_: []
       additionalProperties: false
       _name_: alertclasses_update
-      title: alertclasses_entry
+      title: alertclasses_update
       default: {}
       _attrs_order_:
         - classes
-    alertservice_create_0:
+    alertservice_create:
       type: object
       properties:
         name:
@@ -17345,6 +17914,57 @@ components:
       additionalProperties: false
       _name_: alert_service_create
       title: alert_service_create
+      default: {}
+      _attrs_order_:
+        - name
+        - type
+        - attributes
+        - level
+        - enabled
+    alertservice_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        type:
+          _name_: type
+          title: type
+          type: string
+          description: |-
+            Create an Alert Service of specified `type`.
+            If `enabled`, it sends alerts to the configured `type` of Alert Service.
+              Create an Alert Service of Mail `type`
+        attributes:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: attributes
+          title: attributes
+          default: {}
+          _attrs_order_: []
+        level:
+          _name_: level
+          title: level
+          type: string
+          enum:
+            - INFO
+            - NOTICE
+            - WARNING
+            - ERROR
+            - CRITICAL
+            - ALERT
+            - EMERGENCY
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+          description: If `enabled`, it sends alerts to the configured `type` of Alert Service.
+      additionalProperties: false
+      _name_: alert_service_update
+      title: alert_service_update
       default: {}
       _attrs_order_:
         - name
@@ -17436,7 +18056,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -17456,9 +18076,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/alertservice_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/alertservice_get_instance_1'
-    alertservice_test_0:
+    alertservice_test:
       type: object
       properties:
         name:
@@ -17505,7 +18125,7 @@ components:
         - attributes
         - level
         - enabled
-    api_key_create_0:
+    api_key_create:
       type: object
       properties:
         name:
@@ -17553,6 +18173,59 @@ components:
       _attrs_order_:
         - name
         - allowlist
+    api_key_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        allowlist:
+          _name_: allowlist
+          title: allowlist
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              method:
+                _name_: method
+                title: method
+                _required_: true
+                type: string
+                enum:
+                  - GET
+                  - POST
+                  - PUT
+                  - DELETE
+                  - CALL
+                  - SUBSCRIBE
+                  - '*'
+              resource:
+                _name_: resource
+                title: resource
+                _required_: true
+                type: string
+            additionalProperties: false
+            _name_: allowlist_item
+            title: allowlist_item
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - method
+              - resource
+        reset:
+          type: boolean
+          _name_: reset
+          title: reset
+      additionalProperties: false
+      _name_: api_key_update
+      title: api_key_update
+      default: {}
+      _attrs_order_:
+        - name
+        - allowlist
+        - reset
     api_key_get_instance_0:
       anyOf:
         - type: string
@@ -17637,7 +18310,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -17657,7 +18330,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/api_key_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/api_key_get_instance_1'
     auth_check_password_0:
       _name_: username
@@ -17713,11 +18386,11 @@ components:
           $ref: '#/components/schemas/auth_generate_token_0'
         attrs:
           $ref: '#/components/schemas/auth_generate_token_1'
-    auth_terminate_session_0:
+    auth_terminate_session:
       _name_: id
       title: id
       type: string
-    auth_twofactor_update_0:
+    auth_twofactor_update:
       type: object
       properties:
         enabled:
@@ -17754,7 +18427,7 @@ components:
             - ssh
       additionalProperties: false
       _name_: auth_twofactor_update
-      title: auth_twofactor_entry
+      title: auth_twofactor_update
       default: {}
       _attrs_order_:
         - enabled
@@ -17762,7 +18435,7 @@ components:
         - window
         - interval
         - services
-    auth_twofactor_verify_0:
+    auth_twofactor_verify:
       _name_: token
       title: token
       type: string
@@ -17792,7 +18465,7 @@ components:
           $ref: '#/components/schemas/boot_attach_0'
         options:
           $ref: '#/components/schemas/boot_attach_1'
-    boot_detach_0:
+    boot_detach:
       _name_: dev
       title: dev
       type: string
@@ -17811,11 +18484,11 @@ components:
           $ref: '#/components/schemas/boot_replace_0'
         dev:
           $ref: '#/components/schemas/boot_replace_1'
-    boot_set_scrub_interval_0:
+    boot_set_scrub_interval:
       type: integer
       _name_: interval
       title: interval
-    bootenv_create_0:
+    bootenv_create:
       type: object
       properties:
         name:
@@ -17840,6 +18513,26 @@ components:
       _attrs_order_:
         - name
         - source
+    bootenv_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+          description: |-
+            Update `id` boot environment name with a new provided valid `name`.
+            Create a new boot environment using `name`.
+            Then, a new boot environment of `name` is created using boot environment `source` by cloning it.
+      additionalProperties: false
+      _name_: bootenv_update
+      title: bootenv_update
+      default: {}
+      _attrs_order_:
+        - name
+    bootenv_activate_by_id:
+      type: object
+      properties: {}
     bootenv_get_instance_0:
       anyOf:
         - type: string
@@ -17924,7 +18617,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -17944,9 +18637,23 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/bootenv_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/bootenv_get_instance_1'
-    catalog_create_0:
+    bootenv_set_attribute_by_id:
+      type: object
+      properties:
+        keep:
+          type: boolean
+          _name_: keep
+          title: keep
+          default: false
+      additionalProperties: false
+      _name_: attributes
+      title: attributes
+      default: {}
+      _attrs_order_:
+        - keep
+    catalog_create:
       type: object
       properties:
         label:
@@ -17974,7 +18681,7 @@ components:
           default: false
       additionalProperties: false
       _name_: catalog_create
-      title: catalog_entry
+      title: catalog_create
       default: {}
       _attrs_order_:
         - label
@@ -17982,6 +18689,21 @@ components:
         - branch
         - preferred_trains
         - force
+    catalog_update_by_id:
+      type: object
+      properties:
+        preferred_trains:
+          _name_: preferred_trains
+          title: preferred_trains
+          default: []
+          type: array
+          items: {}
+      additionalProperties: false
+      _name_: catalog_update
+      title: catalog_update
+      default: {}
+      _attrs_order_:
+        - preferred_trains
     catalog_get_instance_0:
       anyOf:
         - type: string
@@ -18066,7 +18788,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -18086,7 +18808,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/catalog_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/catalog_get_instance_1'
     catalog_get_item_details_0:
       _name_: item_name
@@ -18174,16 +18896,16 @@ components:
           $ref: '#/components/schemas/catalog_items_0'
         options:
           $ref: '#/components/schemas/catalog_items_1'
-    catalog_sync_0:
+    catalog_sync:
       _name_: label
       title: label
       type: string
-    catalog_validate_0:
+    catalog_validate:
       _name_: label
       title: label
       type: string
       description: Validates `label` catalog format which includes validating trains and applications with their versions.
-    certificate_create_0:
+    certificate_create:
       type: object
       properties:
         tos:
@@ -18558,6 +19280,37 @@ components:
         - digest_algorithm
         - san
         - cert_extensions
+    certificate_delete_by_id:
+      type: boolean
+      _name_: force
+      title: force
+      default: false
+      description: |-
+        If the certificate is an ACME based certificate, certificate service will try to
+        revoke the certificate by updating it's status with the ACME server, if it fails an exception is raised
+        and the certificate is not deleted from the system. However, if `force` is set to True, certificate is deleted
+        from the system even if some error occurred while revoking the certificate with the ACME Server
+    certificate_update_by_id:
+      type: object
+      properties:
+        revoked:
+          type: boolean
+          _name_: revoked
+          title: revoked
+          description: |-
+            When `revoked` is enabled, the specified cert `id` is revoked and if it belongs to a CA chain which
+            exists on this system, its serial number is added to the CA's certificate revocation list.
+        name:
+          _name_: name
+          title: name
+          type: string
+      additionalProperties: false
+      _name_: certificate_update
+      title: certificate_update
+      default: {}
+      _attrs_order_:
+        - revoked
+        - name
     certificate_get_instance_0:
       anyOf:
         - type: string
@@ -18642,7 +19395,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -18662,9 +19415,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/certificate_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/certificate_get_instance_1'
-    certificateauthority_create_0:
+    certificateauthority_create:
       type: object
       properties:
         tos:
@@ -19006,7 +19759,7 @@ components:
           default: false
       additionalProperties: false
       _name_: ca_create
-      title: certificate_create
+      title: ca_create
       default: {}
       _attrs_order_:
         - tos
@@ -19037,7 +19790,57 @@ components:
         - san
         - cert_extensions
         - add_to_trusted_store
-    certificateauthority_ca_sign_csr_0:
+    certificateauthority_update_by_id:
+      type: object
+      properties:
+        revoked:
+          type: boolean
+          _name_: revoked
+          title: revoked
+          description: |-
+            Only `name` and `revoked` attribute can be updated.
+            If `revoked` is enabled, the CA and its complete chain is marked as revoked and added to the CA's
+            certificate revocation list.
+        add_to_trusted_store:
+          type: boolean
+          _name_: add_to_trusted_store
+          title: add_to_trusted_store
+        ca_id:
+          type: integer
+          _name_: ca_id
+          title: ca_id
+        csr_cert_id:
+          type: integer
+          _name_: csr_cert_id
+          title: csr_cert_id
+        create_type:
+          _name_: create_type
+          title: create_type
+          type: string
+          enum:
+            - CA_SIGN_CSR
+          description: |-
+            Certificate Authorities are classified under following types with the necessary keywords to be passed
+            for `create_type` attribute to create the respective type of certificate authority
+            A type is selected by the Certificate Authority Service based on `create_type`. The rest of the values
+            are validated accordingly and finally a certificate is made based on the selected type.
+        name:
+          _name_: name
+          title: name
+          type: string
+          description: Only `name` and `revoked` attribute can be updated.
+      additionalProperties: false
+      _name_: ca_update
+      title: ca_update
+      default: {}
+      _attrs_order_:
+        - revoked
+        - add_to_trusted_store
+        - ca_id
+        - csr_cert_id
+        - create_type
+        - name
+    certificateauthority_ca_sign_csr:
       type: object
       properties:
         ca_id:
@@ -19337,7 +20140,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -19357,9 +20160,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/certificateauthority_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/certificateauthority_get_instance_1'
-    chart_release_create_0:
+    chart_release_create:
       type: object
       properties:
         values:
@@ -19412,11 +20215,46 @@ components:
         - release_name
         - train
         - version
-    chart_release_events_0:
+    chart_release_delete_by_id:
+      type: object
+      properties:
+        delete_unused_images:
+          type: boolean
+          _name_: delete_unused_images
+          title: delete_unused_images
+          default: false
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - delete_unused_images
+    chart_release_update_by_id:
+      type: object
+      properties:
+        values:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: values
+          title: values
+          default: {}
+          _attrs_order_: []
+          description: |-
+            `values` is configuration specified for the catalog item version in question which will be used to
+            create the chart release.
+            Create a chart release for a catalog item.
+      additionalProperties: false
+      _name_: chart_release_update
+      title: chart_release_update
+      default: {}
+      _attrs_order_:
+        - values
+    chart_release_events:
       _name_: release_name
       title: release_name
       type: string
-    chart_release_get_chart_releases_using_chart_release_images_0:
+    chart_release_get_chart_releases_using_chart_release_images:
       _name_: chart_release_name
       title: chart_release_name
       type: string
@@ -19504,7 +20342,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -19524,9 +20362,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/chart_release_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/chart_release_get_instance_1'
-    chart_release_pod_console_choices_0:
+    chart_release_pod_console_choices:
       _name_: release_name
       title: release_name
       type: string
@@ -19574,11 +20412,11 @@ components:
           $ref: '#/components/schemas/chart_release_pod_logs_0'
         options:
           $ref: '#/components/schemas/chart_release_pod_logs_1'
-    chart_release_pod_logs_choices_0:
+    chart_release_pod_logs_choices:
       _name_: release_name
       title: release_name
       type: string
-    chart_release_pod_status_0:
+    chart_release_pod_status:
       _name_: release_name
       title: release_name
       type: string
@@ -19608,7 +20446,7 @@ components:
           $ref: '#/components/schemas/chart_release_pull_container_images_0'
         pull_container_images_options:
           $ref: '#/components/schemas/chart_release_pull_container_images_1'
-    chart_release_redeploy_0:
+    chart_release_redeploy:
       _name_: release_name
       title: release_name
       type: string
@@ -19820,7 +20658,7 @@ components:
           $ref: '#/components/schemas/chart_release_upgrade_summary_0'
         options:
           $ref: '#/components/schemas/chart_release_upgrade_summary_1'
-    cloudsync_create_0:
+    cloudsync_create:
       type: object
       properties:
         description:
@@ -20033,6 +20871,222 @@ components:
         - post_script
         - args
         - enabled
+    cloudsync_update_by_id:
+      type: object
+      properties:
+        description:
+          _name_: description
+          title: description
+          default: ""
+          type: string
+        direction:
+          _name_: direction
+          title: direction
+          type: string
+          enum:
+            - PUSH
+            - PULL
+        transfer_mode:
+          _name_: transfer_mode
+          title: transfer_mode
+          type: string
+          enum:
+            - SYNC
+            - COPY
+            - MOVE
+        path:
+          _name_: path
+          title: path
+          type: string
+        credentials:
+          type: integer
+          _name_: credentials
+          title: credentials
+        encryption:
+          type: boolean
+          _name_: encryption
+          title: encryption
+          default: false
+        filename_encryption:
+          type: boolean
+          _name_: filename_encryption
+          title: filename_encryption
+          default: false
+        encryption_password:
+          _name_: encryption_password
+          title: encryption_password
+          default: ""
+          type: string
+        encryption_salt:
+          _name_: encryption_salt
+          title: encryption_salt
+          default: ""
+          type: string
+        schedule:
+          type: object
+          properties:
+            minute:
+              _name_: minute
+              title: minute
+              default: "00"
+              type: string
+            hour:
+              _name_: hour
+              title: hour
+              default: '*'
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: '*'
+              type: string
+          additionalProperties: false
+          _name_: schedule
+          title: schedule
+          default: {}
+          _attrs_order_:
+            - minute
+            - hour
+            - dom
+            - month
+            - dow
+        create_empty_src_dirs:
+          type: boolean
+          _name_: create_empty_src_dirs
+          title: create_empty_src_dirs
+          default: false
+        follow_symlinks:
+          type: boolean
+          _name_: follow_symlinks
+          title: follow_symlinks
+          default: false
+        transfers:
+          type: integer
+          _name_: transfers
+          title: transfers
+          default: null
+          nullable: true
+        bwlimit:
+          _name_: bwlimit
+          title: bwlimit
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              time:
+                _name_: time
+                title: time
+                _required_: false
+                type: string
+              bandwidth:
+                type:
+                  - integer
+                  - "null"
+                _name_: bandwidth
+                title: bandwidth
+                _required_: false
+            additionalProperties: false
+            _name_: cloud_sync_bwlimit
+            title: cloud_sync_bwlimit
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - time
+              - bandwidth
+        include:
+          _name_: include
+          title: include
+          default: []
+          type: array
+          items:
+            _name_: path
+            title: path
+            _required_: false
+            type: string
+        exclude:
+          _name_: exclude
+          title: exclude
+          default: []
+          type: array
+          items:
+            _name_: path
+            title: path
+            _required_: false
+            type: string
+        attributes:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: attributes
+          title: attributes
+          default: {}
+          _attrs_order_: []
+        snapshot:
+          type: boolean
+          _name_: snapshot
+          title: snapshot
+          default: false
+        pre_script:
+          _name_: pre_script
+          title: pre_script
+          default: ""
+          type: string
+        post_script:
+          _name_: post_script
+          title: post_script
+          default: ""
+          type: string
+        args:
+          _name_: args
+          title: args
+          default: ""
+          type: string
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+      additionalProperties: false
+      _name_: cloud_sync_update
+      title: cloud_sync_update
+      default: {}
+      _attrs_order_:
+        - description
+        - direction
+        - transfer_mode
+        - path
+        - credentials
+        - encryption
+        - filename_encryption
+        - encryption_password
+        - encryption_salt
+        - schedule
+        - create_empty_src_dirs
+        - follow_symlinks
+        - transfers
+        - bwlimit
+        - include
+        - exclude
+        - attributes
+        - snapshot
+        - pre_script
+        - post_script
+        - args
+        - enabled
+    cloudsync_abort_by_id:
+      type: object
+      properties: {}
     cloudsync_create_bucket_0:
       type: integer
       _name_: credentials_id
@@ -20132,7 +21186,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -20152,13 +21206,13 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/cloudsync_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/cloudsync_get_instance_1'
-    cloudsync_list_buckets_0:
+    cloudsync_list_buckets:
       type: integer
       _name_: credentials_id
       title: credentials_id
-    cloudsync_list_directory_0:
+    cloudsync_list_directory:
       type: object
       properties:
         credentials:
@@ -20214,7 +21268,7 @@ components:
         - encryption_salt
         - attributes
         - args
-    cloudsync_onedrive_list_drives_0:
+    cloudsync_onedrive_list_drives:
       type: object
       properties:
         client_id:
@@ -20239,6 +21293,46 @@ components:
         - client_id
         - client_secret
         - token
+    cloudsync_restore_by_id:
+      type: object
+      properties:
+        description:
+          _name_: description
+          title: description
+          type: string
+        transfer_mode:
+          _name_: transfer_mode
+          title: transfer_mode
+          type: string
+          enum:
+            - SYNC
+            - COPY
+        path:
+          _name_: path
+          title: path
+          type: string
+      additionalProperties: false
+      _name_: cloud_sync_restore
+      title: cloud_sync_restore
+      default: {}
+      _attrs_order_:
+        - description
+        - transfer_mode
+        - path
+    cloudsync_sync_by_id:
+      type: object
+      properties:
+        dry_run:
+          type: boolean
+          _name_: dry_run
+          title: dry_run
+          default: false
+      additionalProperties: false
+      _name_: cloud_sync_sync_options
+      title: cloud_sync_sync_options
+      default: {}
+      _attrs_order_:
+        - dry_run
     cloudsync_sync_onetime_0:
       type: object
       properties:
@@ -20427,7 +21521,7 @@ components:
           default: true
       additionalProperties: false
       _name_: cloud_sync_sync_onetime
-      title: cloud_sync_create
+      title: cloud_sync_sync_onetime
       default: {}
       _attrs_order_:
         - description
@@ -20462,18 +21556,18 @@ components:
           default: false
       additionalProperties: false
       _name_: cloud_sync_sync_onetime_options
-      title: cloud_sync_sync_options
+      title: cloud_sync_sync_onetime_options
       default: {}
       _attrs_order_:
         - dry_run
     cloudsync_sync_onetime:
       type: object
       properties:
-        cloud_sync_create:
+        cloud_sync_sync_onetime:
           $ref: '#/components/schemas/cloudsync_sync_onetime_0'
-        cloud_sync_sync_options:
+        cloud_sync_sync_onetime_options:
           $ref: '#/components/schemas/cloudsync_sync_onetime_1'
-    cloudsync_credentials_create_0:
+    cloudsync_credentials_create:
       type: object
       properties:
         name:
@@ -20495,6 +21589,33 @@ components:
       additionalProperties: false
       _name_: cloud_sync_credentials_create
       title: cloud_sync_credentials_create
+      default: {}
+      _attrs_order_:
+        - name
+        - provider
+        - attributes
+    cloudsync_credentials_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        provider:
+          _name_: provider
+          title: provider
+          type: string
+        attributes:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: attributes
+          title: attributes
+          default: {}
+          _attrs_order_: []
+      additionalProperties: false
+      _name_: cloud_sync_credentials_update
+      title: cloud_sync_credentials_update
       default: {}
       _attrs_order_:
         - name
@@ -20584,7 +21705,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -20604,9 +21725,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/cloudsync_credentials_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/cloudsync_credentials_get_instance_1'
-    cloudsync_credentials_verify_0:
+    cloudsync_credentials_verify:
       type: object
       properties:
         provider:
@@ -20628,7 +21749,7 @@ components:
       _attrs_order_:
         - provider
         - attributes
-    config_reset_0:
+    config_reset:
       type: object
       properties:
         reboot:
@@ -20642,7 +21763,7 @@ components:
       default: {}
       _attrs_order_:
         - reboot
-    config_save_0:
+    config_save:
       type: object
       properties:
         secretseed:
@@ -20678,7 +21799,7 @@ components:
         - pool_keys
         - root_authorized_keys
         - gluster_config
-    container_update_0:
+    container_update:
       type: object
       properties:
         enable_image_updates:
@@ -20687,11 +21808,11 @@ components:
           title: enable_image_updates
       additionalProperties: false
       _name_: container_update
-      title: container_entry
+      title: container_update
       default: {}
       _attrs_order_:
         - enable_image_updates
-    container_prune_0:
+    container_prune:
       type: object
       properties:
         remove_unused_images:
@@ -20711,7 +21832,21 @@ components:
       _attrs_order_:
         - remove_unused_images
         - remove_stopped_containers
-    container_image_get_chart_releases_consuming_image_0:
+    container_image_delete_by_id:
+      type: object
+      properties:
+        force:
+          type: boolean
+          _name_: force
+          title: force
+          default: false
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - force
+    container_image_get_chart_releases_consuming_image:
       _name_: image_tags
       title: image_tags
       default: []
@@ -20805,7 +21940,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -20825,9 +21960,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/container_image_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/container_image_get_instance_1'
-    container_image_pull_0:
+    container_image_pull:
       type: object
       properties:
         docker_authentication:
@@ -20872,7 +22007,7 @@ components:
         - docker_authentication
         - from_image
         - tag
-    cronjob_create_0:
+    cronjob_create:
       type: object
       properties:
         enabled:
@@ -20948,6 +22083,91 @@ components:
       additionalProperties: false
       _name_: cron_job_create
       title: cron_job_create
+      default: {}
+      _attrs_order_:
+        - enabled
+        - stderr
+        - stdout
+        - schedule
+        - command
+        - description
+        - user
+    cronjob_update_by_id:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+        stderr:
+          type: boolean
+          _name_: stderr
+          title: stderr
+          default: false
+          description: |-
+            `stderr` and `stdout` are boolean values which if `true`, represent that we would like to suppress
+            standard error / standard output respectively.
+        stdout:
+          type: boolean
+          _name_: stdout
+          title: stdout
+          default: true
+          description: |-
+            `stderr` and `stdout` are boolean values which if `true`, represent that we would like to suppress
+            standard error / standard output respectively.
+        schedule:
+          type: object
+          properties:
+            minute:
+              _name_: minute
+              title: minute
+              default: "00"
+              type: string
+            hour:
+              _name_: hour
+              title: hour
+              default: '*'
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: '*'
+              type: string
+          additionalProperties: false
+          _name_: schedule
+          title: schedule
+          default: {}
+          _attrs_order_:
+            - minute
+            - hour
+            - dom
+            - month
+            - dow
+        command:
+          _name_: command
+          title: command
+          type: string
+        description:
+          _name_: description
+          title: description
+          type: string
+        user:
+          _name_: user
+          title: user
+          type: string
+      additionalProperties: false
+      _name_: cronjob_update
+      title: cronjob_update
       default: {}
       _attrs_order_:
         - enabled
@@ -21041,7 +22261,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -21061,7 +22281,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/cronjob_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/cronjob_get_instance_1'
     cronjob_run_0:
       type: integer
@@ -21079,7 +22299,7 @@ components:
           $ref: '#/components/schemas/cronjob_run_0'
         skip_disabled:
           $ref: '#/components/schemas/cronjob_run_1'
-    ctdb_general_ips_0:
+    ctdb_general_ips:
       type: object
       properties:
         all_nodes:
@@ -21093,7 +22313,7 @@ components:
       default: {}
       _attrs_order_:
         - all_nodes
-    ctdb_general_status_0:
+    ctdb_general_status:
       type: object
       properties:
         all_nodes:
@@ -21111,7 +22331,7 @@ components:
       default: {}
       _attrs_order_:
         - all_nodes
-    ctdb_private_ips_create_0:
+    ctdb_private_ips_create:
       type: object
       properties:
         ip:
@@ -21124,6 +22344,22 @@ components:
       default: {}
       _attrs_order_:
         - ip
+    ctdb_private_ips_update_by_id:
+      type: object
+      properties:
+        enable:
+          type: boolean
+          _name_: enable
+          title: enable
+          description: |-
+            `enable` boolean. When True, enable the node else disable the node.
+            Add a ctdb private address to the cluster
+      additionalProperties: false
+      _name_: private_update
+      title: private_update
+      default: {}
+      _attrs_order_:
+        - enable
     ctdb_private_ips_get_instance_0:
       anyOf:
         - type: string
@@ -21208,7 +22444,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -21228,9 +22464,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/ctdb_private_ips_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/ctdb_private_ips_get_instance_1'
-    ctdb_public_ips_create_0:
+    ctdb_public_ips_create:
       type: object
       properties:
         pnn:
@@ -21261,6 +22497,11 @@ components:
         - ip
         - netmask
         - interface
+    ctdb_public_ips_delete_by_id:
+      type: integer
+      _name_: pnn
+      title: pnn
+      default: null
     ctdb_public_ips_get_instance_0:
       anyOf:
         - type: string
@@ -21345,7 +22586,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -21365,9 +22606,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/ctdb_public_ips_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/ctdb_public_ips_get_instance_1'
-    ctdb_public_ips_interface_choices_0:
+    ctdb_public_ips_interface_choices:
       _name_: exclude_ifaces
       title: exclude_ifaces
       default: []
@@ -21377,7 +22618,7 @@ components:
         title: exclude_iface
         _required_: false
         type: string
-    device_get_info_0:
+    device_get_info:
       _name_: type
       title: type
       type: string
@@ -21385,6 +22626,144 @@ components:
         - SERIAL
         - DISK
         - GPU
+    disk_update_by_id:
+      type: object
+      properties:
+        number:
+          type: integer
+          _name_: number
+          title: number
+        lunid:
+          _name_: lunid
+          title: lunid
+          type: string
+          nullable: true
+        description:
+          _name_: description
+          title: description
+          type: string
+        hddstandby:
+          _name_: hddstandby
+          title: hddstandby
+          type: string
+          enum:
+            - ALWAYS ON
+            - "5"
+            - "10"
+            - "20"
+            - "30"
+            - "60"
+            - "120"
+            - "180"
+            - "240"
+            - "300"
+            - "330"
+        togglesmart:
+          type: boolean
+          _name_: togglesmart
+          title: togglesmart
+        advpowermgmt:
+          _name_: advpowermgmt
+          title: advpowermgmt
+          type: string
+          enum:
+            - DISABLED
+            - "1"
+            - "64"
+            - "127"
+            - "128"
+            - "192"
+            - "254"
+        smartoptions:
+          _name_: smartoptions
+          title: smartoptions
+          type: string
+          description: '`smartoptions`.'
+        critical:
+          type: integer
+          _name_: critical
+          title: critical
+          description: |-
+            `critical`, `informational` and `difference` are integer values on which alerts for SMART are configured
+            if the disk temperature crosses the assigned threshold for each respective attribute.
+            If they are set to null, then SMARTD config values are used as defaults.
+            Email of log level LOG_CRIT is issued when disk temperature crosses `critical`.
+          nullable: true
+        difference:
+          type: integer
+          _name_: difference
+          title: difference
+          description: |-
+            `critical`, `informational` and `difference` are integer values on which alerts for SMART are configured
+            if the disk temperature crosses the assigned threshold for each respective attribute.
+            If they are set to null, then SMARTD config values are used as defaults.
+          nullable: true
+        informational:
+          type: integer
+          _name_: informational
+          title: informational
+          description: |-
+            `critical`, `informational` and `difference` are integer values on which alerts for SMART are configured
+            if the disk temperature crosses the assigned threshold for each respective attribute.
+            If they are set to null, then SMARTD config values are used as defaults.
+            Email of log level LOG_INFO is issued when disk temperature crosses `informational`.
+          nullable: true
+        bus:
+          _name_: bus
+          title: bus
+          type: string
+        enclosure:
+          type: object
+          properties:
+            number:
+              type: integer
+              _name_: number
+              title: number
+            slot:
+              type: integer
+              _name_: slot
+              title: slot
+          additionalProperties: false
+          _name_: enclosure
+          title: enclosure
+          default: {}
+          _attrs_order_:
+            - number
+            - slot
+        pool:
+          _name_: pool
+          title: pool
+          type: string
+          nullable: true
+        passwd:
+          _name_: passwd
+          title: passwd
+          type: string
+        supports_smart:
+          type: boolean
+          _name_: supports_smart
+          title: supports_smart
+          nullable: true
+      additionalProperties: false
+      _name_: disk_update
+      title: disk_update
+      default: {}
+      _attrs_order_:
+        - number
+        - lunid
+        - description
+        - hddstandby
+        - togglesmart
+        - advpowermgmt
+        - smartoptions
+        - critical
+        - difference
+        - informational
+        - bus
+        - enclosure
+        - pool
+        - passwd
+        - supports_smart
     disk_get_instance_0:
       anyOf:
         - type: string
@@ -21469,7 +22848,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -21489,9 +22868,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/disk_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/disk_get_instance_1'
-    disk_get_unused_0:
+    disk_get_unused:
       type: boolean
       _name_: join_partitions
       title: join_partitions
@@ -21548,7 +22927,7 @@ components:
           $ref: '#/components/schemas/disk_resize_1'
         raise_error:
           $ref: '#/components/schemas/disk_resize_2'
-    disk_smart_attributes_0:
+    disk_smart_attributes:
       _name_: name
       title: name
       type: string
@@ -21610,7 +22989,7 @@ components:
           $ref: '#/components/schemas/disk_temperature_agg_0'
         days:
           $ref: '#/components/schemas/disk_temperature_agg_1'
-    disk_temperature_alerts_0:
+    disk_temperature_alerts:
       _name_: names
       title: names
       default: []
@@ -21711,7 +23090,7 @@ components:
           $ref: '#/components/schemas/disk_wipe_2'
         swap_removal_options:
           $ref: '#/components/schemas/disk_wipe_3'
-    dyndns_update_0:
+    dyndns_update:
       type: object
       properties:
         provider:
@@ -21767,7 +23146,7 @@ components:
           description: '`period` indicates how often the IP is checked in seconds.'
       additionalProperties: false
       _name_: dyndns_update
-      title: dyndns_entry
+      title: dyndns_update
       default: {}
       _attrs_order_:
         - provider
@@ -21781,6 +23160,19 @@ components:
         - username
         - password
         - period
+    enclosure_update_by_id:
+      type: object
+      properties:
+        label:
+          _name_: label
+          title: label
+          type: string
+      additionalProperties: false
+      _name_: enclosure_update
+      title: enclosure_update
+      default: {}
+      _attrs_order_:
+        - label
     enclosure_get_instance_0:
       anyOf:
         - type: string
@@ -21865,7 +23257,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -21885,7 +23277,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/enclosure_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/enclosure_get_instance_1'
     enclosure_set_slot_status_0:
       _name_: enclosure_id
@@ -21912,7 +23304,7 @@ components:
           $ref: '#/components/schemas/enclosure_set_slot_status_1'
         status:
           $ref: '#/components/schemas/enclosure_set_slot_status_2'
-    failover_update_0:
+    failover_update:
       type: object
       properties:
         disabled:
@@ -21938,7 +23330,7 @@ components:
           nullable: true
       additionalProperties: false
       _name_: failover_update
-      title: failover_entry
+      title: failover_update
       default: {}
       _attrs_order_:
         - disabled
@@ -22041,7 +23433,7 @@ components:
           $ref: '#/components/schemas/failover_control_0'
         options:
           $ref: '#/components/schemas/failover_control_1'
-    failover_sync_to_peer_0:
+    failover_sync_to_peer:
       type: object
       properties:
         reboot:
@@ -22055,7 +23447,7 @@ components:
       default: {}
       _attrs_order_:
         - reboot
-    failover_unlock_0:
+    failover_unlock:
       type: object
       properties:
         pools:
@@ -22117,7 +23509,7 @@ components:
       _attrs_order_:
         - pools
         - datasets
-    failover_upgrade_0:
+    failover_upgrade:
       type: object
       properties:
         train:
@@ -22130,7 +23522,7 @@ components:
       default: {}
       _attrs_order_:
         - train
-    filesystem_acl_is_trivial_0:
+    filesystem_acl_is_trivial:
       _name_: path
       title: path
       type: string
@@ -22180,7 +23572,7 @@ components:
           $ref: '#/components/schemas/filesystem_can_access_as_user_1'
         permissions:
           $ref: '#/components/schemas/filesystem_can_access_as_user_2'
-    filesystem_chown_0:
+    filesystem_chown:
       type: object
       properties:
         path:
@@ -22237,12 +23629,12 @@ components:
         - uid
         - gid
         - options
-    filesystem_default_acl_choices_0:
+    filesystem_default_acl_choices:
       _name_: path
       title: path
       default: ""
       type: string
-    filesystem_get_0:
+    filesystem_get:
       _name_: path
       title: path
       type: string
@@ -22267,7 +23659,7 @@ components:
           $ref: '#/components/schemas/filesystem_get_default_acl_0'
         share_type:
           $ref: '#/components/schemas/filesystem_get_default_acl_1'
-    filesystem_get_dosmode_0:
+    filesystem_get_dosmode:
       _name_: path
       title: path
       type: string
@@ -22308,7 +23700,7 @@ components:
           $ref: '#/components/schemas/filesystem_getacl_1'
         resolve_ids:
           $ref: '#/components/schemas/filesystem_getacl_2'
-    filesystem_is_immutable_0:
+    filesystem_is_immutable:
       _name_: path
       title: path
       type: string
@@ -22419,7 +23811,7 @@ components:
           $ref: '#/components/schemas/filesystem_listdir_1'
         query-options:
           $ref: '#/components/schemas/filesystem_listdir_2'
-    filesystem_mkdir_0:
+    filesystem_mkdir:
       _name_: path
       title: path
       type: string
@@ -22453,7 +23845,7 @@ components:
           $ref: '#/components/schemas/filesystem_put_0'
         options:
           $ref: '#/components/schemas/filesystem_put_1'
-    filesystem_set_dosmode_0:
+    filesystem_set_dosmode:
       type: object
       properties:
         path:
@@ -22526,7 +23918,7 @@ components:
           $ref: '#/components/schemas/filesystem_set_immutable_0'
         path:
           $ref: '#/components/schemas/filesystem_set_immutable_1'
-    filesystem_setacl_0:
+    filesystem_setacl:
       type: object
       properties:
         path:
@@ -22900,7 +24292,7 @@ components:
         - nfs41_flags
         - acltype
         - options
-    filesystem_setperm_0:
+    filesystem_setperm:
       type: object
       properties:
         path:
@@ -22976,16 +24368,16 @@ components:
         - uid
         - gid
         - options
-    filesystem_stat_0:
+    filesystem_stat:
       _name_: path
       title: path
       type: string
       description: Return the filesystem stat(2) for a given `path`.
-    filesystem_statfs_0:
+    filesystem_statfs:
       _name_: path
       title: path
       type: string
-    filesystem_acltemplate_create_0:
+    filesystem_acltemplate_create:
       type: object
       properties:
         name:
@@ -23286,7 +24678,308 @@ components:
         - acltype
         - comment
         - acl
-    filesystem_acltemplate_by_path_0:
+    filesystem_acltemplate_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        acltype:
+          _name_: acltype
+          title: acltype
+          type: string
+          enum:
+            - NFS4
+            - POSIX1E
+        comment:
+          _name_: comment
+          title: comment
+          type: string
+        acl:
+          anyOf:
+            - _name_: nfs4_acl
+              title: nfs4_acl
+              default: []
+              _required_: false
+              type: array
+              items:
+                - type: object
+                  properties:
+                    tag:
+                      _name_: tag
+                      title: tag
+                      _required_: false
+                      type: string
+                      enum:
+                        - owner@
+                        - group@
+                        - everyone@
+                        - USER
+                        - GROUP
+                    id:
+                      type:
+                        - integer
+                        - "null"
+                      _name_: id
+                      title: id
+                      _required_: false
+                    type:
+                      _name_: type
+                      title: type
+                      _required_: false
+                      type: string
+                      enum:
+                        - ALLOW
+                        - DENY
+                    perms:
+                      type: object
+                      properties:
+                        READ_DATA:
+                          type: boolean
+                          _name_: READ_DATA
+                          title: READ_DATA
+                          _required_: false
+                        WRITE_DATA:
+                          type: boolean
+                          _name_: WRITE_DATA
+                          title: WRITE_DATA
+                          _required_: false
+                        APPEND_DATA:
+                          type: boolean
+                          _name_: APPEND_DATA
+                          title: APPEND_DATA
+                          _required_: false
+                        READ_NAMED_ATTRS:
+                          type: boolean
+                          _name_: READ_NAMED_ATTRS
+                          title: READ_NAMED_ATTRS
+                          _required_: false
+                        WRITE_NAMED_ATTRS:
+                          type: boolean
+                          _name_: WRITE_NAMED_ATTRS
+                          title: WRITE_NAMED_ATTRS
+                          _required_: false
+                        EXECUTE:
+                          type: boolean
+                          _name_: EXECUTE
+                          title: EXECUTE
+                          _required_: false
+                        DELETE_CHILD:
+                          type: boolean
+                          _name_: DELETE_CHILD
+                          title: DELETE_CHILD
+                          _required_: false
+                        READ_ATTRIBUTES:
+                          type: boolean
+                          _name_: READ_ATTRIBUTES
+                          title: READ_ATTRIBUTES
+                          _required_: false
+                        WRITE_ATTRIBUTES:
+                          type: boolean
+                          _name_: WRITE_ATTRIBUTES
+                          title: WRITE_ATTRIBUTES
+                          _required_: false
+                        DELETE:
+                          type: boolean
+                          _name_: DELETE
+                          title: DELETE
+                          _required_: false
+                        READ_ACL:
+                          type: boolean
+                          _name_: READ_ACL
+                          title: READ_ACL
+                          _required_: false
+                        WRITE_ACL:
+                          type: boolean
+                          _name_: WRITE_ACL
+                          title: WRITE_ACL
+                          _required_: false
+                        WRITE_OWNER:
+                          type: boolean
+                          _name_: WRITE_OWNER
+                          title: WRITE_OWNER
+                          _required_: false
+                        SYNCHRONIZE:
+                          type: boolean
+                          _name_: SYNCHRONIZE
+                          title: SYNCHRONIZE
+                          _required_: false
+                        BASIC:
+                          _name_: BASIC
+                          title: BASIC
+                          _required_: false
+                          type: string
+                          enum:
+                            - FULL_CONTROL
+                            - MODIFY
+                            - READ
+                            - TRAVERSE
+                      additionalProperties: false
+                      _name_: perms
+                      title: perms
+                      default: {}
+                      _required_: false
+                      _attrs_order_:
+                        - READ_DATA
+                        - WRITE_DATA
+                        - APPEND_DATA
+                        - READ_NAMED_ATTRS
+                        - WRITE_NAMED_ATTRS
+                        - EXECUTE
+                        - DELETE_CHILD
+                        - READ_ATTRIBUTES
+                        - WRITE_ATTRIBUTES
+                        - DELETE
+                        - READ_ACL
+                        - WRITE_ACL
+                        - WRITE_OWNER
+                        - SYNCHRONIZE
+                        - BASIC
+                    flags:
+                      type: object
+                      properties:
+                        FILE_INHERIT:
+                          type: boolean
+                          _name_: FILE_INHERIT
+                          title: FILE_INHERIT
+                          _required_: false
+                        DIRECTORY_INHERIT:
+                          type: boolean
+                          _name_: DIRECTORY_INHERIT
+                          title: DIRECTORY_INHERIT
+                          _required_: false
+                        NO_PROPAGATE_INHERIT:
+                          type: boolean
+                          _name_: NO_PROPAGATE_INHERIT
+                          title: NO_PROPAGATE_INHERIT
+                          _required_: false
+                        INHERIT_ONLY:
+                          type: boolean
+                          _name_: INHERIT_ONLY
+                          title: INHERIT_ONLY
+                          _required_: false
+                        INHERITED:
+                          type: boolean
+                          _name_: INHERITED
+                          title: INHERITED
+                          _required_: false
+                        BASIC:
+                          _name_: BASIC
+                          title: BASIC
+                          _required_: false
+                          type: string
+                          enum:
+                            - INHERIT
+                            - NOINHERIT
+                      additionalProperties: false
+                      _name_: flags
+                      title: flags
+                      default: {}
+                      _required_: false
+                      _attrs_order_:
+                        - FILE_INHERIT
+                        - DIRECTORY_INHERIT
+                        - NO_PROPAGATE_INHERIT
+                        - INHERIT_ONLY
+                        - INHERITED
+                        - BASIC
+                  additionalProperties: false
+                  _name_: nfs4_ace
+                  title: nfs4_ace
+                  default: {}
+                  _required_: false
+                  _attrs_order_:
+                    - tag
+                    - id
+                    - type
+                    - perms
+                    - flags
+            - _name_: posix1e_acl
+              title: posix1e_acl
+              default: []
+              _required_: false
+              type: array
+              items:
+                - type: object
+                  properties:
+                    default:
+                      type: boolean
+                      _name_: default
+                      title: default
+                      default: false
+                      _required_: false
+                    tag:
+                      _name_: tag
+                      title: tag
+                      _required_: false
+                      type: string
+                      enum:
+                        - USER_OBJ
+                        - GROUP_OBJ
+                        - USER
+                        - GROUP
+                        - OTHER
+                        - MASK
+                    id:
+                      type: integer
+                      _name_: id
+                      title: id
+                      default: -1
+                      _required_: false
+                    perms:
+                      type: object
+                      properties:
+                        READ:
+                          type: boolean
+                          _name_: READ
+                          title: READ
+                          default: false
+                          _required_: false
+                        WRITE:
+                          type: boolean
+                          _name_: WRITE
+                          title: WRITE
+                          default: false
+                          _required_: false
+                        EXECUTE:
+                          type: boolean
+                          _name_: EXECUTE
+                          title: EXECUTE
+                          default: false
+                          _required_: false
+                      additionalProperties: false
+                      _name_: perms
+                      title: perms
+                      default: {}
+                      _required_: false
+                      _attrs_order_:
+                        - READ
+                        - WRITE
+                        - EXECUTE
+                  additionalProperties: false
+                  _name_: posix1e_ace
+                  title: posix1e_ace
+                  default: {}
+                  _required_: false
+                  _attrs_order_:
+                    - default
+                    - tag
+                    - id
+                    - perms
+          nullable: false
+          _name_: acl
+          description: null
+      additionalProperties: false
+      _name_: acltemplate_update
+      title: acltemplate_update
+      default: {}
+      _attrs_order_:
+        - name
+        - acltype
+        - comment
+        - acl
+    filesystem_acltemplate_by_path:
       type: object
       properties:
         path:
@@ -23508,7 +25201,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -23528,9 +25221,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/filesystem_acltemplate_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/filesystem_acltemplate_get_instance_1'
-    ftp_update_0:
+    ftp_update:
       type: object
       properties:
         port:
@@ -23768,7 +25461,7 @@ components:
           type: string
       additionalProperties: false
       _name_: ftp_update
-      title: ftp_entry
+      title: ftp_update
       default: {}
       _attrs_order_:
         - port
@@ -23812,7 +25505,7 @@ components:
         - tls_opt_ip_address_required
         - ssltls_certificate
         - options
-    gluster_eventsd_create_0:
+    gluster_eventsd_create:
       type: object
       properties:
         url:
@@ -23843,7 +25536,7 @@ components:
         - url
         - bearer_token
         - secret
-    gluster_eventsd_delete_0:
+    gluster_eventsd_delete:
       type: object
       properties:
         url:
@@ -23857,7 +25550,7 @@ components:
       default: {}
       _attrs_order_:
         - url
-    gluster_fuse_is_mounted_0:
+    gluster_fuse_is_mounted:
       type: object
       properties:
         name:
@@ -23870,7 +25563,7 @@ components:
       default: {}
       _attrs_order_:
         - name
-    gluster_fuse_mount_0:
+    gluster_fuse_mount:
       type: object
       properties:
         name:
@@ -23900,7 +25593,7 @@ components:
         - name
         - all
         - raise
-    gluster_fuse_umount_0:
+    gluster_fuse_umount:
       type: object
       properties:
         name:
@@ -23930,7 +25623,7 @@ components:
         - name
         - all
         - raise
-    gluster_localevents_add_jwt_secret_0:
+    gluster_localevents_add_jwt_secret:
       type: object
       properties:
         secret:
@@ -23961,7 +25654,7 @@ components:
       _attrs_order_:
         - secret
         - force
-    gluster_peer_create_0:
+    gluster_peer_create:
       type: object
       properties:
         hostname:
@@ -24058,7 +25751,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -24078,9 +25771,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/gluster_peer_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/gluster_peer_get_instance_1'
-    gluster_peer_status_0:
+    gluster_peer_status:
       type: object
       properties:
         localhost:
@@ -24094,7 +25787,7 @@ components:
       default: {}
       _attrs_order_:
         - localhost
-    gluster_volume_create_0:
+    gluster_volume_create:
       type: object
       properties:
         name:
@@ -24258,7 +25951,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -24278,9 +25971,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/gluster_volume_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/gluster_volume_get_instance_1'
-    gluster_volume_info_0:
+    gluster_volume_info:
       type: object
       properties:
         name:
@@ -24293,7 +25986,7 @@ components:
       default: {}
       _attrs_order_:
         - name
-    gluster_volume_optreset_0:
+    gluster_volume_optreset:
       type: object
       properties:
         name:
@@ -24322,7 +26015,7 @@ components:
         - name
         - opt
         - force
-    gluster_volume_optset_0:
+    gluster_volume_optset:
       type: object
       properties:
         name:
@@ -24345,7 +26038,7 @@ components:
       _attrs_order_:
         - name
         - opts
-    gluster_volume_quota_0:
+    gluster_volume_quota:
       type: object
       properties:
         name:
@@ -24364,7 +26057,7 @@ components:
       _attrs_order_:
         - name
         - enable
-    gluster_volume_restart_0:
+    gluster_volume_restart:
       type: object
       properties:
         name:
@@ -24384,7 +26077,7 @@ components:
       _attrs_order_:
         - name
         - force
-    gluster_volume_start_0:
+    gluster_volume_start:
       type: object
       properties:
         name:
@@ -24404,7 +26097,7 @@ components:
       _attrs_order_:
         - name
         - force
-    gluster_volume_status_0:
+    gluster_volume_status:
       type: object
       properties:
         name:
@@ -24424,7 +26117,7 @@ components:
       _attrs_order_:
         - name
         - verbose
-    gluster_volume_stop_0:
+    gluster_volume_stop:
       type: object
       properties:
         name:
@@ -24444,7 +26137,7 @@ components:
       _attrs_order_:
         - name
         - force
-    group_create_0:
+    group_create:
       type: object
       properties:
         gid:
@@ -24511,7 +26204,88 @@ components:
         - sudo_commands
         - allow_duplicate_gid
         - users
-    group_get_group_obj_0:
+    group_delete_by_id:
+      type: object
+      properties:
+        delete_users:
+          type: boolean
+          _name_: delete_users
+          title: delete_users
+          default: false
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - delete_users
+    group_update_by_id:
+      type: object
+      properties:
+        gid:
+          type: integer
+          _name_: gid
+          title: gid
+          description: If `gid` is not provided it is automatically filled with the next one available.
+        name:
+          _name_: name
+          title: name
+          type: string
+        smb:
+          type: boolean
+          _name_: smb
+          title: smb
+          default: true
+        sudo:
+          type: boolean
+          _name_: sudo
+          title: sudo
+          default: false
+        sudo_nopasswd:
+          type: boolean
+          _name_: sudo_nopasswd
+          title: sudo_nopasswd
+          default: false
+        sudo_commands:
+          _name_: sudo_commands
+          title: sudo_commands
+          default: []
+          type: array
+          items:
+            _name_: command
+            title: command
+            _required_: false
+            type: string
+        allow_duplicate_gid:
+          type: boolean
+          _name_: allow_duplicate_gid
+          title: allow_duplicate_gid
+          default: false
+          description: '`allow_duplicate_gid` allows distinct group names to share the same gid.'
+        users:
+          _name_: users
+          title: users
+          default: []
+          type: array
+          items:
+            type: integer
+            _name_: id
+            title: id
+            _required_: false
+          description: '`users` is a list of user ids (`id` attribute from `user.query`).'
+      additionalProperties: false
+      _name_: group_update
+      title: group_update
+      default: {}
+      _attrs_order_:
+        - gid
+        - name
+        - smb
+        - sudo
+        - sudo_nopasswd
+        - sudo_commands
+        - allow_duplicate_gid
+        - users
+    group_get_group_obj:
       type: object
       properties:
         groupname:
@@ -24615,7 +26389,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -24635,7 +26409,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/group_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/group_get_instance_1'
     group_has_password_enabled_user_0:
       _name_: gids
@@ -24664,7 +26438,7 @@ components:
           $ref: '#/components/schemas/group_has_password_enabled_user_0'
         exclude_user_ids:
           $ref: '#/components/schemas/group_has_password_enabled_user_1'
-    idmap_create_0:
+    idmap_create:
       type: object
       properties:
         name:
@@ -24979,6 +26753,321 @@ components:
         - idmap_backend
         - certificate
         - options
+    idmap_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+          description: '`name` the pre-windows 2000 domain name.'
+        dns_domain_name:
+          _name_: dns_domain_name
+          title: dns_domain_name
+          type: string
+        range_low:
+          type: integer
+          _name_: range_low
+          title: range_low
+          description: |-
+            `range_low` and `range_high` specify the UID and GID range for which this backend is authoritative.
+            `range_low` and `range_high` specify the UID and GID range for which this backend is authoritative.
+        range_high:
+          type: integer
+          _name_: range_high
+          title: range_high
+          description: |-
+            `range_low` and `range_high` specify the UID and GID range for which this backend is authoritative.
+            `range_low` and `range_high` specify the UID and GID range for which this backend is authoritative.
+        idmap_backend:
+          _name_: idmap_backend
+          title: idmap_backend
+          type: string
+          enum:
+            - AD
+            - AUTORID
+            - LDAP
+            - NSS
+            - RFC2307
+            - RID
+            - TDB
+          description: |-
+            `idmap_backend` provides a plugin interface for Winbind to use varying
+            backends to store SID/uid/gid mapping tables. The correct setting
+            depends on the environment in which the NAS is deployed.
+        certificate:
+          type: integer
+          _name_: certificate
+          title: certificate
+          nullable: true
+        options:
+          anyOf:
+            - type: object
+              properties:
+                schema_mode:
+                  _name_: schema_mode
+                  title: nss_info_ad
+                  default: SFU
+                  _required_: false
+                  type: string
+                  enum:
+                    - SFU
+                    - SFU20
+                    - RFC2307
+                unix_primary_group:
+                  type: boolean
+                  _name_: unix_primary_group
+                  title: unix_primary_group
+                  default: false
+                  _required_: false
+                unix_nss_info:
+                  type: boolean
+                  _name_: unix_nss_info
+                  title: unix_nss_info
+                  default: false
+                  _required_: false
+              additionalProperties: false
+              _name_: idmap_ad_options
+              title: idmap_ad_options
+              default: {}
+              _required_: false
+              _attrs_order_:
+                - schema_mode
+                - unix_primary_group
+                - unix_nss_info
+            - type: object
+              properties:
+                rangesize:
+                  type: integer
+                  _name_: rangesize
+                  title: rangesize
+                  default: 100000
+                  _required_: false
+                readonly:
+                  type: boolean
+                  _name_: readonly
+                  title: readonly
+                  default: false
+                  _required_: false
+                ignore_builtin:
+                  type: boolean
+                  _name_: ignore_builtin
+                  title: ignore_builtin
+                  default: false
+                  _required_: false
+              additionalProperties: false
+              _name_: idmap_autorid_options
+              title: idmap_autorid_options
+              default: {}
+              _required_: false
+              _attrs_order_:
+                - rangesize
+                - readonly
+                - ignore_builtin
+            - type: object
+              properties:
+                ldap_base_dn:
+                  _name_: ldap_base_dn
+                  title: ldap_base_dn
+                  _required_: false
+                  type: string
+                ldap_user_dn:
+                  _name_: ldap_user_dn
+                  title: ldap_user_dn
+                  _required_: false
+                  type: string
+                ldap_user_dn_password:
+                  _name_: ldap_user_dn_password
+                  title: ldap_user_dn_password
+                  _required_: false
+                  type: string
+                ldap_url:
+                  _name_: ldap_url
+                  title: ldap_url
+                  _required_: false
+                  type: string
+                readonly:
+                  type: boolean
+                  _name_: readonly
+                  title: readonly
+                  default: false
+                  _required_: false
+                ssl:
+                  _name_: ssl
+                  title: ldap_ssl_choice
+                  default: "ON"
+                  _required_: false
+                  type: string
+                  enum:
+                    - "OFF"
+                    - "ON"
+                    - START_TLS
+                validate_certificates:
+                  type: boolean
+                  _name_: validate_certificates
+                  title: validate_certificates
+                  default: true
+                  _required_: false
+              additionalProperties: false
+              _name_: idmap_ldap_options
+              title: idmap_ldap_options
+              default: {}
+              _required_: false
+              _attrs_order_:
+                - ldap_base_dn
+                - ldap_user_dn
+                - ldap_user_dn_password
+                - ldap_url
+                - readonly
+                - ssl
+                - validate_certificates
+            - type: object
+              properties:
+                linked_service:
+                  _name_: linked_service
+                  title: linked_service
+                  default: LOCAL_ACCOUNT
+                  _required_: false
+                  type: string
+                  enum:
+                    - LOCAL_ACCOUNT
+                    - LDAP
+              additionalProperties: false
+              _name_: idmap_nss_options
+              title: idmap_nss_options
+              default: {}
+              _required_: false
+              _attrs_order_:
+                - linked_service
+            - type: object
+              properties:
+                ldap_server:
+                  _name_: ldap_server
+                  title: ldap_server
+                  _required_: true
+                  type: string
+                  enum:
+                    - AD
+                    - STANDALONE
+                ldap_realm:
+                  type: boolean
+                  _name_: ldap_realm
+                  title: ldap_realm
+                  default: false
+                  _required_: false
+                bind_path_user:
+                  _name_: bind_path_user
+                  title: bind_path_user
+                  _required_: false
+                  type: string
+                bind_path_group:
+                  _name_: bind_path_group
+                  title: bind_path_group
+                  _required_: false
+                  type: string
+                user_cn:
+                  type: boolean
+                  _name_: user_cn
+                  title: user_cn
+                  default: false
+                  _required_: false
+                cn_realm:
+                  _name_: cn_realm
+                  title: cn_realm
+                  _required_: false
+                  type: string
+                ldap_domain:
+                  _name_: ldap_domain
+                  title: ldap_domain
+                  _required_: false
+                  type: string
+                ldap_url:
+                  _name_: ldap_url
+                  title: ldap_url
+                  _required_: false
+                  type: string
+                ldap_user_dn:
+                  _name_: ldap_user_dn
+                  title: ldap_user_dn
+                  _required_: false
+                  type: string
+                ldap_user_dn_password:
+                  _name_: ldap_user_dn_password
+                  title: ldap_user_dn_password
+                  _required_: false
+                  type: string
+                ssl:
+                  _name_: ssl
+                  title: ldap_ssl_choice
+                  default: "ON"
+                  _required_: false
+                  type: string
+                  enum:
+                    - "OFF"
+                    - "ON"
+                    - START_TLS
+                validate_certificates:
+                  type: boolean
+                  _name_: validate_certificates
+                  title: validate_certificates
+                  default: true
+                  _required_: false
+              additionalProperties: false
+              _name_: idmap_rfc2307_options
+              title: idmap_rfc2307_options
+              default: {}
+              _required_: false
+              _attrs_order_:
+                - ldap_server
+                - ldap_realm
+                - bind_path_user
+                - bind_path_group
+                - user_cn
+                - cn_realm
+                - ldap_domain
+                - ldap_url
+                - ldap_user_dn
+                - ldap_user_dn_password
+                - ssl
+                - validate_certificates
+            - type: object
+              properties:
+                sssd_compat:
+                  type: boolean
+                  _name_: sssd_compat
+                  title: sssd_compat
+                  default: false
+                  _required_: false
+              additionalProperties: false
+              _name_: idmap_rid_options
+              title: idmap_rid_options
+              default: {}
+              _required_: false
+              _attrs_order_:
+                - sssd_compat
+            - type: object
+              properties: {}
+              additionalProperties: false
+              _name_: idmap_tdb_options
+              title: idmap_tdb_options
+              default: {}
+              _required_: false
+              _attrs_order_: []
+          nullable: false
+          _name_: options
+          description: '`options` are additional parameters that are backend-dependent:'
+      additionalProperties: false
+      _name_: idmap_update
+      title: idmap_update
+      default: {}
+      _attrs_order_:
+        - name
+        - dns_domain_name
+        - range_low
+        - range_high
+        - idmap_backend
+        - certificate
+        - options
     idmap_get_instance_0:
       anyOf:
         - type: string
@@ -25063,7 +27152,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -25083,9 +27172,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/idmap_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/idmap_get_instance_1'
-    idmap_options_choices_0:
+    idmap_options_choices:
       _name_: idmap_backend
       title: idmap_backend
       type: string
@@ -25097,7 +27186,7 @@ components:
         - RFC2307
         - RID
         - TDB
-    initshutdownscript_create_0:
+    initshutdownscript_create:
       type: object
       properties:
         type:
@@ -25152,6 +27241,71 @@ components:
       additionalProperties: false
       _name_: init_shutdown_script_create
       title: init_shutdown_script_create
+      default: {}
+      _attrs_order_:
+        - type
+        - command
+        - script_text
+        - script
+        - when
+        - enabled
+        - timeout
+        - comment
+    initshutdownscript_update_by_id:
+      type: object
+      properties:
+        type:
+          _name_: type
+          title: type
+          type: string
+          enum:
+            - COMMAND
+            - SCRIPT
+          description: '`type` indicates if a command or script should be executed at `when`.'
+        command:
+          _name_: command
+          title: command
+          type: string
+          nullable: true
+        script_text:
+          _name_: script_text
+          title: script_text
+          type: string
+          nullable: true
+        script:
+          _name_: script
+          title: script
+          type: string
+          nullable: true
+        when:
+          _name_: when
+          title: when
+          type: string
+          enum:
+            - PREINIT
+            - POSTINIT
+            - SHUTDOWN
+          description: |-
+            `type` indicates if a command or script should be executed at `when`.
+            There are three choices for `when`:
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+        timeout:
+          type: integer
+          _name_: timeout
+          title: timeout
+          default: 10
+        comment:
+          _name_: comment
+          title: comment
+          default: ""
+          type: string
+      additionalProperties: false
+      _name_: initshutdownscript_update
+      title: initshutdownscript_update
       default: {}
       _attrs_order_:
         - type
@@ -25246,7 +27400,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -25266,9 +27420,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/initshutdownscript_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/initshutdownscript_get_instance_1'
-    interface_create_0:
+    interface_create:
       type: object
       properties:
         name:
@@ -25510,13 +27664,240 @@ components:
         - vlan_tag
         - vlan_pcp
         - mtu
-    interface_bridge_members_choices_0:
+    interface_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        description:
+          _name_: description
+          title: description
+          default: ""
+          type: string
+        ipv4_dhcp:
+          type: boolean
+          _name_: ipv4_dhcp
+          title: ipv4_dhcp
+          default: false
+        ipv6_auto:
+          type: boolean
+          _name_: ipv6_auto
+          title: ipv6_auto
+          default: false
+        aliases:
+          _name_: aliases
+          title: aliases
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                _name_: type
+                title: type
+                default: INET
+                _required_: true
+                type: string
+                enum:
+                  - INET
+                  - INET6
+              address:
+                _name_: address
+                title: address
+                _required_: true
+                type: string
+              netmask:
+                type: integer
+                _name_: netmask
+                title: netmask
+                _required_: true
+            additionalProperties: false
+            _name_: interface_alias
+            title: interface_alias
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - type
+              - address
+              - netmask
+        failover_critical:
+          type: boolean
+          _name_: failover_critical
+          title: failover_critical
+          default: false
+        failover_group:
+          type: integer
+          _name_: failover_group
+          title: failover_group
+          nullable: true
+        failover_vhid:
+          type: integer
+          _name_: failover_vhid
+          title: failover_vhid
+          nullable: true
+        failover_aliases:
+          _name_: failover_aliases
+          title: failover_aliases
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                _name_: type
+                title: type
+                default: INET
+                _required_: true
+                type: string
+                enum:
+                  - INET
+                  - INET6
+              address:
+                _name_: address
+                title: address
+                _required_: true
+                type: string
+            additionalProperties: false
+            _name_: interface_failover_alias
+            title: interface_failover_alias
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - type
+              - address
+        failover_virtual_aliases:
+          _name_: failover_virtual_aliases
+          title: failover_virtual_aliases
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                _name_: type
+                title: type
+                default: INET
+                _required_: true
+                type: string
+                enum:
+                  - INET
+                  - INET6
+              address:
+                _name_: address
+                title: address
+                _required_: true
+                type: string
+            additionalProperties: false
+            _name_: interface_virtual_alias
+            title: interface_virtual_alias
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - type
+              - address
+        bridge_members:
+          _name_: bridge_members
+          title: bridge_members
+          default: []
+          type: array
+          items: {}
+        stp:
+          type: boolean
+          _name_: stp
+          title: stp
+          default: true
+        lag_protocol:
+          _name_: lag_protocol
+          title: lag_protocol
+          type: string
+          enum:
+            - LACP
+            - FAILOVER
+            - LOADBALANCE
+            - ROUNDROBIN
+            - NONE
+        xmit_hash_policy:
+          _name_: xmit_hash_policy
+          title: xmit_hash_policy
+          default: null
+          type: string
+          enum:
+            - LAYER2
+            - LAYER2+3
+            - LAYER3+4
+          nullable: true
+        lacpdu_rate:
+          _name_: lacpdu_rate
+          title: lacpdu_rate
+          default: null
+          type: string
+          enum:
+            - SLOW
+            - FAST
+          nullable: true
+        lag_ports:
+          _name_: lag_ports
+          title: lag_ports
+          default: []
+          type: array
+          items:
+            _name_: interface
+            title: interface
+            _required_: false
+            type: string
+        vlan_parent_interface:
+          _name_: vlan_parent_interface
+          title: vlan_parent_interface
+          type: string
+        vlan_tag:
+          type: integer
+          _name_: vlan_tag
+          title: vlan_tag
+        vlan_pcp:
+          type: integer
+          _name_: vlan_pcp
+          title: vlan_pcp
+          nullable: true
+        mtu:
+          type: integer
+          _name_: mtu
+          title: mtu
+          default: null
+          nullable: true
+      additionalProperties: false
+      _name_: interface_update
+      title: interface_update
+      default: {}
+      _attrs_order_:
+        - name
+        - description
+        - ipv4_dhcp
+        - ipv6_auto
+        - aliases
+        - failover_critical
+        - failover_group
+        - failover_vhid
+        - failover_aliases
+        - failover_virtual_aliases
+        - bridge_members
+        - stp
+        - lag_protocol
+        - xmit_hash_policy
+        - lacpdu_rate
+        - lag_ports
+        - vlan_parent_interface
+        - vlan_tag
+        - vlan_pcp
+        - mtu
+    interface_bridge_members_choices:
       _name_: id
       title: id
       default: null
       type: string
       nullable: true
-    interface_choices_0:
+    interface_choices:
       type: object
       properties:
         bridge_members:
@@ -25580,7 +27961,7 @@ components:
         - exclude
         - exclude_types
         - include
-    interface_commit_0:
+    interface_commit:
       type: object
       properties:
         rollback:
@@ -25685,7 +28066,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -25705,9 +28086,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/interface_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/interface_get_instance_1'
-    interface_ip_in_use_0:
+    interface_ip_in_use:
       type: object
       properties:
         ipv4:
@@ -25754,21 +28135,21 @@ components:
         - loopback
         - any
         - static
-    interface_lag_ports_choices_0:
+    interface_lag_ports_choices:
       _name_: id
       title: id
       default: null
       type: string
       nullable: true
-    interface_save_default_route_0:
+    interface_save_default_route:
       _name_: gw
       title: gw
       type: string
-    interface_capabilities_get_0:
+    interface_capabilities_get:
       _name_: name
       title: name
       type: string
-    interface_capabilities_set_0:
+    interface_capabilities_set:
       type: object
       properties:
         name:
@@ -25799,6 +28180,62 @@ components:
         - name
         - capabilties
         - action
+    ipmi_update_by_id:
+      type: object
+      properties:
+        ipaddress:
+          _name_: ipaddress
+          title: ipaddress
+          type: string
+          description: |-
+            `ipaddress` is an IPv4 address to be assigned to channel number `id`.
+            `netmask` is the subnet mask associated with `ipaddress`.
+            `gateway` is an IPv4 address used by `ipaddress` to reach outside the local subnet.
+            `dhcp` is a boolean. If False, `ipaddress`, `netmask` and `gateway` must be set.
+        netmask:
+          _name_: netmask
+          title: netmask
+          type: string
+          description: |-
+            `ipaddress` is an IPv4 address to be assigned to channel number `id`.
+            `netmask` is the subnet mask associated with `ipaddress`.
+            `gateway` is an IPv4 address used by `ipaddress` to reach outside the local subnet.
+            `dhcp` is a boolean. If False, `ipaddress`, `netmask` and `gateway` must be set.
+        gateway:
+          _name_: gateway
+          title: gateway
+          type: string
+          description: |-
+            `ipaddress` is an IPv4 address to be assigned to channel number `id`.
+            `netmask` is the subnet mask associated with `ipaddress`.
+            `gateway` is an IPv4 address used by `ipaddress` to reach outside the local subnet.
+            `dhcp` is a boolean. If False, `ipaddress`, `netmask` and `gateway` must be set.
+        password:
+          _name_: password
+          title: password
+          type: string
+          description: '`password` is a password to be assigned to channel number `id`'
+        dhcp:
+          type: boolean
+          _name_: dhcp
+          title: dhcp
+          description: '`dhcp` is a boolean. If False, `ipaddress`, `netmask` and `gateway` must be set.'
+        vlan:
+          type: integer
+          _name_: vlan
+          title: vlan
+          nullable: true
+      additionalProperties: false
+      _name_: ipmi_update
+      title: ipmi_update
+      default: {}
+      _attrs_order_:
+        - ipaddress
+        - netmask
+        - gateway
+        - password
+        - dhcp
+        - vlan
     ipmi_get_instance_0:
       anyOf:
         - type: string
@@ -25883,7 +28320,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -25903,9 +28340,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/ipmi_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/ipmi_get_instance_1'
-    ipmi_identify_0:
+    ipmi_identify:
       type: object
       properties:
         seconds:
@@ -25929,7 +28366,7 @@ components:
       _attrs_order_:
         - seconds
         - force
-    iscsi_auth_create_0:
+    iscsi_auth_create:
       type: object
       properties:
         tag:
@@ -25960,6 +28397,44 @@ components:
       additionalProperties: false
       _name_: iscsi_auth_create
       title: iscsi_auth_create
+      default: {}
+      _attrs_order_:
+        - tag
+        - user
+        - secret
+        - peeruser
+        - peersecret
+    iscsi_auth_update_by_id:
+      type: object
+      properties:
+        tag:
+          type: integer
+          _name_: tag
+          title: tag
+          description: '`tag` should be unique among all configured iSCSI Authorized Accesses.'
+        user:
+          _name_: user
+          title: user
+          type: string
+        secret:
+          _name_: secret
+          title: secret
+          type: string
+          description: '`secret` and `peersecret` should have length between 12-16 letters inclusive.'
+        peeruser:
+          _name_: peeruser
+          title: peeruser
+          default: ""
+          type: string
+        peersecret:
+          _name_: peersecret
+          title: peersecret
+          default: ""
+          type: string
+          description: '`secret` and `peersecret` should have length between 12-16 letters inclusive.'
+      additionalProperties: false
+      _name_: iscsi_auth_update
+      title: iscsi_auth_update
       default: {}
       _attrs_order_:
         - tag
@@ -26051,7 +28526,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -26071,9 +28546,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/iscsi_auth_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/iscsi_auth_get_instance_1'
-    iscsi_extent_create_0:
+    iscsi_extent_create:
       type: object
       properties:
         name:
@@ -26197,6 +28672,147 @@ components:
         - rpm
         - ro
         - enabled
+    iscsi_extent_delete_by_id_1:
+      type: boolean
+      _name_: remove
+      title: remove
+      default: false
+    iscsi_extent_delete_by_id_2:
+      type: boolean
+      _name_: force
+      title: force
+      default: false
+    iscsi_extent_delete_by_id:
+      type: object
+      properties:
+        remove:
+          $ref: '#/components/schemas/iscsi_extent_delete_by_id_1'
+        force:
+          $ref: '#/components/schemas/iscsi_extent_delete_by_id_2'
+    iscsi_extent_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        type:
+          _name_: type
+          title: type
+          default: DISK
+          type: string
+          enum:
+            - DISK
+            - FILE
+          description: |-
+            When `type` is set to FILE, attribute `filesize` is used and it represents number of bytes. `filesize` if
+            not zero should be a multiple of `blocksize`. `path` is a required attribute with `type` set as FILE.
+            With `type` being set to DISK, a valid ZFS volume is required.
+        disk:
+          _name_: disk
+          title: disk
+          default: null
+          type: string
+          nullable: true
+        serial:
+          _name_: serial
+          title: serial
+          default: null
+          type: string
+          nullable: true
+        path:
+          _name_: path
+          title: path
+          default: null
+          type: string
+          description: |-
+            When `type` is set to FILE, attribute `filesize` is used and it represents number of bytes. `filesize` if
+            not zero should be a multiple of `blocksize`. `path` is a required attribute with `type` set as FILE.
+          nullable: true
+        filesize:
+          type: integer
+          _name_: filesize
+          title: filesize
+          default: 0
+          description: |-
+            When `type` is set to FILE, attribute `filesize` is used and it represents number of bytes. `filesize` if
+            not zero should be a multiple of `blocksize`. `path` is a required attribute with `type` set as FILE.
+        blocksize:
+          type: integer
+          _name_: blocksize
+          title: blocksize
+          default: 512
+          description: |-
+            When `type` is set to FILE, attribute `filesize` is used and it represents number of bytes. `filesize` if
+            not zero should be a multiple of `blocksize`. `path` is a required attribute with `type` set as FILE.
+        pblocksize:
+          type: boolean
+          _name_: pblocksize
+          title: pblocksize
+        avail_threshold:
+          type: integer
+          _name_: avail_threshold
+          title: avail_threshold
+          nullable: true
+        comment:
+          _name_: comment
+          title: comment
+          type: string
+        insecure_tpc:
+          type: boolean
+          _name_: insecure_tpc
+          title: insecure_tpc
+          default: true
+          description: |-
+            `insecure_tpc` when enabled allows an initiator to bypass normal access control and access any scannable
+            target. This allows xcopy operations otherwise blocked by access control.
+        xen:
+          type: boolean
+          _name_: xen
+          title: xen
+          description: '`xen` is a boolean value which is set to true if Xen is being used as the iSCSI initiator.'
+        rpm:
+          _name_: rpm
+          title: rpm
+          default: SSD
+          type: string
+          enum:
+            - UNKNOWN
+            - SSD
+            - "5400"
+            - "7200"
+            - "10000"
+            - "15000"
+        ro:
+          type: boolean
+          _name_: ro
+          title: ro
+          default: false
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+      additionalProperties: false
+      _name_: iscsi_extent_update
+      title: iscsi_extent_update
+      default: {}
+      _attrs_order_:
+        - name
+        - type
+        - disk
+        - serial
+        - path
+        - filesize
+        - blocksize
+        - pblocksize
+        - avail_threshold
+        - comment
+        - insecure_tpc
+        - xen
+        - rpm
+        - ro
+        - enabled
     iscsi_extent_get_instance_0:
       anyOf:
         - type: string
@@ -26281,7 +28897,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -26301,9 +28917,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/iscsi_extent_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/iscsi_extent_get_instance_1'
-    iscsi_global_update_0:
+    iscsi_global_update:
       type: object
       properties:
         basename:
@@ -26344,7 +28960,7 @@ components:
         - listen_port
         - pool_avail_threshold
         - alua
-    iscsi_host_create_0:
+    iscsi_host_create:
       type: object
       properties:
         ip:
@@ -26382,7 +28998,45 @@ components:
         - description
         - iqns
         - added_automatically
-    iscsi_host_get_initiators_0:
+    iscsi_host_update_by_id:
+      type: object
+      properties:
+        ip:
+          _name_: ip
+          title: ip
+          type: string
+          description: '`ip` indicates an IP address of the host.'
+        description:
+          _name_: description
+          title: description
+          default: ""
+          type: string
+          description: '`description` is a human-readable name for the host.'
+        iqns:
+          _name_: iqns
+          title: iqns
+          default: []
+          type: array
+          items:
+            _name_: iqn
+            title: iqn
+            _required_: false
+            type: string
+        added_automatically:
+          type: boolean
+          _name_: added_automatically
+          title: added_automatically
+          default: false
+      additionalProperties: false
+      _name_: iscsi_host_update
+      title: iscsi_host_update
+      default: {}
+      _attrs_order_:
+        - ip
+        - description
+        - iqns
+        - added_automatically
+    iscsi_host_get_initiators:
       type: integer
       _name_: id
       title: id
@@ -26470,7 +29124,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -26490,9 +29144,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/iscsi_host_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/iscsi_host_get_instance_1'
-    iscsi_host_get_targets_0:
+    iscsi_host_get_targets:
       type: integer
       _name_: id
       title: id
@@ -26547,7 +29201,7 @@ components:
           $ref: '#/components/schemas/iscsi_host_set_targets_0'
         ids:
           $ref: '#/components/schemas/iscsi_host_set_targets_1'
-    iscsi_initiator_create_0:
+    iscsi_initiator_create:
       type: object
       properties:
         initiators:
@@ -26563,6 +29217,26 @@ components:
       additionalProperties: false
       _name_: iscsi_initiator_create
       title: iscsi_initiator_create
+      default: {}
+      _attrs_order_:
+        - initiators
+        - comment
+    iscsi_initiator_update_by_id:
+      type: object
+      properties:
+        initiators:
+          _name_: initiators
+          title: initiators
+          default: []
+          type: array
+          items: {}
+        comment:
+          _name_: comment
+          title: comment
+          type: string
+      additionalProperties: false
+      _name_: iscsi_initiator_update
+      title: iscsi_initiator_update
       default: {}
       _attrs_order_:
         - initiators
@@ -26651,7 +29325,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -26671,9 +29345,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/iscsi_initiator_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/iscsi_initiator_get_instance_1'
-    iscsi_portal_create_0:
+    iscsi_portal_create:
       type: object
       properties:
         comment:
@@ -26718,6 +29392,57 @@ components:
       additionalProperties: false
       _name_: iscsiportal_create
       title: iscsiportal_create
+      default: {}
+      _attrs_order_:
+        - comment
+        - discovery_authmethod
+        - discovery_authgroup
+        - listen
+    iscsi_portal_update_by_id:
+      type: object
+      properties:
+        comment:
+          _name_: comment
+          title: comment
+          type: string
+        discovery_authmethod:
+          _name_: discovery_authmethod
+          title: discovery_authmethod
+          default: NONE
+          type: string
+          enum:
+            - NONE
+            - CHAP
+            - CHAP_MUTUAL
+        discovery_authgroup:
+          type: integer
+          _name_: discovery_authgroup
+          title: discovery_authgroup
+          default: null
+          nullable: true
+        listen:
+          _name_: listen
+          title: listen
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              ip:
+                _name_: ip
+                title: ip
+                _required_: true
+                type: string
+            additionalProperties: false
+            _name_: listen
+            title: listen
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - ip
+      additionalProperties: false
+      _name_: iscsiportal_update
+      title: iscsiportal_update
       default: {}
       _attrs_order_:
         - comment
@@ -26808,7 +29533,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -26828,9 +29553,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/iscsi_portal_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/iscsi_portal_get_instance_1'
-    iscsi_target_create_0:
+    iscsi_target_create:
       type: object
       properties:
         name:
@@ -26924,6 +29649,105 @@ components:
         - mode
         - groups
         - auth_networks
+    iscsi_target_delete_by_id:
+      type: boolean
+      _name_: force
+      title: force
+      default: false
+    iscsi_target_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        alias:
+          _name_: alias
+          title: alias
+          type: string
+          nullable: true
+        mode:
+          _name_: mode
+          title: mode
+          default: ISCSI
+          type: string
+          enum:
+            - ISCSI
+            - FC
+            - BOTH
+        groups:
+          _name_: groups
+          title: groups
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              portal:
+                type: integer
+                _name_: portal
+                title: portal
+                _required_: true
+              initiator:
+                type:
+                  - integer
+                  - "null"
+                _name_: initiator
+                title: initiator
+                default: null
+                _required_: false
+              authmethod:
+                _name_: authmethod
+                title: authmethod
+                default: NONE
+                _required_: false
+                type: string
+                enum:
+                  - NONE
+                  - CHAP
+                  - CHAP_MUTUAL
+              auth:
+                type:
+                  - integer
+                  - "null"
+                _name_: auth
+                title: auth
+                default: null
+                _required_: false
+            additionalProperties: false
+            _name_: group
+            title: group
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - portal
+              - initiator
+              - authmethod
+              - auth
+          description: |-
+            `groups` is a list of group dictionaries which provide information related to using a `portal`, `initiator`,
+            `authmethod` and `auth` with this target. `auth` represents a valid iSCSI Authorized Access and defaults to
+            null.
+        auth_networks:
+          _name_: auth_networks
+          title: auth_networks
+          default: []
+          type: array
+          items:
+            _name_: ip
+            title: ip
+            _required_: false
+            type: string
+      additionalProperties: false
+      _name_: iscsi_target_update
+      title: iscsi_target_update
+      default: {}
+      _attrs_order_:
+        - name
+        - alias
+        - mode
+        - groups
+        - auth_networks
     iscsi_target_get_instance_0:
       anyOf:
         - type: string
@@ -27008,7 +29832,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -27028,9 +29852,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/iscsi_target_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/iscsi_target_get_instance_1'
-    iscsi_targetextent_create_0:
+    iscsi_targetextent_create:
       type: object
       properties:
         target:
@@ -27049,6 +29873,34 @@ components:
       additionalProperties: false
       _name_: iscsi_targetextent_create
       title: iscsi_targetextent_create
+      default: {}
+      _attrs_order_:
+        - target
+        - lunid
+        - extent
+    iscsi_targetextent_delete_by_id:
+      type: boolean
+      _name_: force
+      title: force
+      default: false
+    iscsi_targetextent_update_by_id:
+      type: object
+      properties:
+        target:
+          type: integer
+          _name_: target
+          title: target
+        lunid:
+          type: integer
+          _name_: lunid
+          title: lunid
+        extent:
+          type: integer
+          _name_: extent
+          title: extent
+      additionalProperties: false
+      _name_: iscsi_targetextent_update
+      title: iscsi_targetextent_update
       default: {}
       _attrs_order_:
         - target
@@ -27138,7 +29990,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -27158,9 +30010,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/iscsi_targetextent_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/iscsi_targetextent_get_instance_1'
-    kerberos_update_0:
+    kerberos_update:
       type: object
       properties:
         appdefaults_aux:
@@ -27179,7 +30031,7 @@ components:
       _attrs_order_:
         - appdefaults_aux
         - libdefaults_aux
-    kerberos_keytab_create_0:
+    kerberos_keytab_create:
       type: object
       properties:
         file:
@@ -27194,6 +30046,25 @@ components:
       additionalProperties: false
       _name_: kerberos_keytab_create
       title: kerberos_keytab_create
+      default: {}
+      _attrs_order_:
+        - file
+        - name
+    kerberos_keytab_update_by_id:
+      type: object
+      properties:
+        file:
+          _name_: file
+          title: file
+          type: string
+          description: '`file` b64encoded kerberos keytab'
+        name:
+          _name_: name
+          title: name
+          type: string
+      additionalProperties: false
+      _name_: kerberos_keytab_update
+      title: kerberos_keytab_update
       default: {}
       _attrs_order_:
         - file
@@ -27282,7 +30153,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -27302,9 +30173,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/kerberos_keytab_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/kerberos_keytab_get_instance_1'
-    kerberos_keytab_upload_keytab_0:
+    kerberos_keytab_upload_keytab:
       type: object
       properties:
         name:
@@ -27317,7 +30188,7 @@ components:
       default: {}
       _attrs_order_:
         - name
-    kerberos_realm_create_0:
+    kerberos_realm_create:
       type: object
       properties:
         realm:
@@ -27345,6 +30216,40 @@ components:
       additionalProperties: false
       _name_: kerberos_realm_create
       title: kerberos_realm_create
+      default: {}
+      _attrs_order_:
+        - realm
+        - kdc
+        - admin_server
+        - kpasswd_server
+    kerberos_realm_update_by_id:
+      type: object
+      properties:
+        realm:
+          _name_: realm
+          title: realm
+          type: string
+        kdc:
+          _name_: kdc
+          title: kdc
+          default: []
+          type: array
+          items: {}
+        admin_server:
+          _name_: admin_server
+          title: admin_server
+          default: []
+          type: array
+          items: {}
+        kpasswd_server:
+          _name_: kpasswd_server
+          title: kpasswd_server
+          default: []
+          type: array
+          items: {}
+      additionalProperties: false
+      _name_: kerberos_realm_update
+      title: kerberos_realm_update
       default: {}
       _attrs_order_:
         - realm
@@ -27435,7 +30340,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -27455,9 +30360,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/kerberos_realm_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/kerberos_realm_get_instance_1'
-    keychaincredential_create_0:
+    keychaincredential_create:
       type: object
       properties:
         name:
@@ -27508,6 +30413,69 @@ components:
       _attrs_order_:
         - name
         - type
+        - attributes
+    keychaincredential_delete_by_id:
+      type: object
+      properties:
+        cascade:
+          type: boolean
+          _name_: cascade
+          title: cascade
+          default: false
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - cascade
+    keychaincredential_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+          description: |-
+            Every Keychain Credential has a `name` which is used to distinguish it from others.
+            The following `type`s are supported:
+             * `SSH_KEY_PAIR`
+               Which `attributes` are:
+               * `private_key`
+               * `public_key` (which can be omitted and thus automatically derived from private key)
+               At least one attribute is required.
+        attributes:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: attributes
+          title: attributes
+          default: {}
+          _attrs_order_: []
+          description: |-
+            Also you must specify full `attributes` value
+            Every Keychain Credential has a `name` which is used to distinguish it from others.
+            The following `type`s are supported:
+             * `SSH_KEY_PAIR`
+               Which `attributes` are:
+               * `private_key`
+               * `public_key` (which can be omitted and thus automatically derived from private key)
+               At least one attribute is required.
+             * `SSH_CREDENTIALS`
+               Which `attributes` are:
+               * `host`
+               * `port` (default 22)
+               * `username` (default root)
+               * `private_key` (Keychain Credential ID)
+               * `remote_host_key` (you can use `keychaincredential.remote_ssh_host_key_scan` do discover it)
+               * `cipher`: one of `STANDARD`, `FAST`, or `DISABLED` (last requires special support from both SSH server and
+                 client)
+               * `connect_timeout` (default 10)
+      additionalProperties: false
+      _name_: keychain_credential_update
+      title: keychain_credential_update
+      default: {}
+      _attrs_order_:
+        - name
         - attributes
     keychaincredential_get_instance_0:
       anyOf:
@@ -27593,7 +30561,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -27613,9 +30581,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/keychaincredential_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/keychaincredential_get_instance_1'
-    keychaincredential_remote_ssh_host_key_scan_0:
+    keychaincredential_remote_ssh_host_key_scan:
       type: object
       properties:
         host:
@@ -27640,7 +30608,7 @@ components:
         - host
         - port
         - connect_timeout
-    keychaincredential_remote_ssh_semiautomatic_setup_0:
+    keychaincredential_remote_ssh_semiautomatic_setup:
       type: object
       properties:
         name:
@@ -27728,7 +30696,7 @@ components:
         - private_key
         - cipher
         - connect_timeout
-    keychaincredential_setup_ssh_connection_0:
+    keychaincredential_setup_ssh_connection:
       type: object
       properties:
         private_key:
@@ -27815,7 +30783,7 @@ components:
               default: 10
           additionalProperties: false
           _name_: semi_automatic_setup
-          title: keychain_remote_ssh_semiautomatic_setup
+          title: semi_automatic_setup
           default: null
           _attrs_order_:
             - url
@@ -27844,11 +30812,11 @@ components:
         - setup_type
         - semi_automatic_setup
         - manual_setup
-    keychaincredential_used_by_0:
+    keychaincredential_used_by:
       type: integer
       _name_: id
       title: id
-    kmip_update_0:
+    kmip_update:
       type: object
       properties:
         enabled:
@@ -27937,7 +30905,7 @@ components:
             it's reachable.
       additionalProperties: false
       _name_: kmip_update
-      title: kmip_entry
+      title: kmip_update
       default: {}
       _attrs_order_:
         - enabled
@@ -27951,7 +30919,7 @@ components:
         - force_clear
         - change_server
         - validate
-    kubernetes_update_0:
+    kubernetes_update:
       type: object
       properties:
         servicelb:
@@ -28077,7 +31045,7 @@ components:
             - passphrase
       additionalProperties: false
       _name_: kubernetes_update
-      title: kubernetes_entry
+      title: kubernetes_update
       default: {}
       _attrs_order_:
         - servicelb
@@ -28095,13 +31063,13 @@ components:
         - migrate_applications
         - force
         - migration_options
-    kubernetes_backup_chart_releases_0:
+    kubernetes_backup_chart_releases:
       _name_: backup_name
       title: backup_name
       default: null
       type: string
       nullable: true
-    kubernetes_delete_backup_0:
+    kubernetes_delete_backup:
       _name_: backup_name
       title: backup_name
       type: string
@@ -28131,7 +31099,7 @@ components:
           $ref: '#/components/schemas/kubernetes_restore_backup_0'
         options:
           $ref: '#/components/schemas/kubernetes_restore_backup_1'
-    ldap_update_0:
+    ldap_update:
       type: object
       properties:
         hostname:
@@ -28301,7 +31269,7 @@ components:
         - auxiliary_parameters
         - schema
         - enable
-    mail_update_0:
+    mail_update:
       type: object
       properties:
         fromemail:
@@ -28370,7 +31338,7 @@ components:
             - refresh_token
       additionalProperties: false
       _name_: mail_update
-      title: mail_entry
+      title: mail_update
       default: {}
       _attrs_order_:
         - fromemail
@@ -28543,7 +31511,7 @@ components:
             - refresh_token
       additionalProperties: false
       _name_: mail_update
-      title: mail_entry
+      title: mail_update
       default: {}
       _attrs_order_:
         - fromemail
@@ -28560,9 +31528,9 @@ components:
       properties:
         mail_message:
           $ref: '#/components/schemas/mail_send_0'
-        mail_entry:
+        mail_update:
           $ref: '#/components/schemas/mail_send_1'
-    network_configuration_update_0:
+    network_configuration_update:
       type: object
       properties:
         hostname:
@@ -28698,7 +31666,7 @@ components:
           nullable: true
       additionalProperties: false
       _name_: global_configuration_update
-      title: network_configuration_entry
+      title: global_configuration_update
       default: {}
       _attrs_order_:
         - hostname
@@ -28717,7 +31685,7 @@ components:
         - activity
         - hostname_b
         - hostname_virtual
-    nfs_update_0:
+    nfs_update:
       type: object
       properties:
         servers:
@@ -28799,7 +31767,7 @@ components:
           title: userd_manage_gids
       additionalProperties: false
       _name_: nfs_update
-      title: nfs_entry
+      title: nfs_update
       default: {}
       _attrs_order_:
         - servers
@@ -28816,7 +31784,7 @@ components:
         - mountd_log
         - statd_lockd_log
         - userd_manage_gids
-    nfs_add_principal_0:
+    nfs_add_principal:
       type: object
       properties:
         username:
@@ -28834,7 +31802,7 @@ components:
       _attrs_order_:
         - username
         - password
-    openvpn_client_update_0:
+    openvpn_client_update:
       type: object
       properties:
         nobind:
@@ -28916,7 +31884,7 @@ components:
           default: false
       additionalProperties: false
       _name_: openvpn_client_update
-      title: openvpn_client_entry
+      title: openvpn_client_update
       default: {}
       _attrs_order_:
         - nobind
@@ -28933,7 +31901,7 @@ components:
         - remote
         - tls_crypt_auth
         - remove_certificates
-    openvpn_server_update_0:
+    openvpn_server_update:
       type: object
       properties:
         tls_crypt_auth_enabled:
@@ -29023,7 +31991,7 @@ components:
           default: false
       additionalProperties: false
       _name_: openvpn_server_update
-      title: openvpn_server_entry
+      title: openvpn_server_update
       default: {}
       _attrs_order_:
         - tls_crypt_auth_enabled
@@ -29059,7 +32027,7 @@ components:
           $ref: '#/components/schemas/openvpn_server_client_configuration_generation_0'
         server_address:
           $ref: '#/components/schemas/openvpn_server_client_configuration_generation_1'
-    pool_create_0:
+    pool_create:
       type: object
       properties:
         name:
@@ -29387,6 +32355,234 @@ components:
         - encryption_options
         - topology
         - allow_duplicate_serials
+    pool_update_by_id:
+      type: object
+      properties:
+        topology:
+          type: object
+          properties:
+            data:
+              _name_: data
+              title: data
+              default: []
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    _name_: type
+                    title: type
+                    _required_: true
+                    type: string
+                    enum:
+                      - RAIDZ1
+                      - RAIDZ2
+                      - RAIDZ3
+                      - MIRROR
+                      - STRIPE
+                  disks:
+                    _name_: disks
+                    title: disks
+                    default: []
+                    _required_: true
+                    type: array
+                    items:
+                      - _name_: disk
+                        title: disk
+                        _required_: false
+                        type: string
+                additionalProperties: false
+                _name_: datavdevs
+                title: datavdevs
+                default: {}
+                _required_: false
+                _attrs_order_:
+                  - type
+                  - disks
+            special:
+              _name_: special
+              title: special
+              default: []
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    _name_: type
+                    title: type
+                    _required_: true
+                    type: string
+                    enum:
+                      - MIRROR
+                      - STRIPE
+                  disks:
+                    _name_: disks
+                    title: disks
+                    default: []
+                    _required_: true
+                    type: array
+                    items:
+                      - _name_: disk
+                        title: disk
+                        _required_: false
+                        type: string
+                additionalProperties: false
+                _name_: specialvdevs
+                title: specialvdevs
+                default: {}
+                _required_: false
+                _attrs_order_:
+                  - type
+                  - disks
+            dedup:
+              _name_: dedup
+              title: dedup
+              default: []
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    _name_: type
+                    title: type
+                    _required_: true
+                    type: string
+                    enum:
+                      - MIRROR
+                      - STRIPE
+                  disks:
+                    _name_: disks
+                    title: disks
+                    default: []
+                    _required_: true
+                    type: array
+                    items:
+                      - _name_: disk
+                        title: disk
+                        _required_: false
+                        type: string
+                additionalProperties: false
+                _name_: dedupvdevs
+                title: dedupvdevs
+                default: {}
+                _required_: false
+                _attrs_order_:
+                  - type
+                  - disks
+            cache:
+              _name_: cache
+              title: cache
+              default: []
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    _name_: type
+                    title: type
+                    _required_: true
+                    type: string
+                    enum:
+                      - STRIPE
+                  disks:
+                    _name_: disks
+                    title: disks
+                    default: []
+                    _required_: true
+                    type: array
+                    items:
+                      - _name_: disk
+                        title: disk
+                        _required_: false
+                        type: string
+                additionalProperties: false
+                _name_: cachevdevs
+                title: cachevdevs
+                default: {}
+                _required_: false
+                _attrs_order_:
+                  - type
+                  - disks
+            log:
+              _name_: log
+              title: log
+              default: []
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    _name_: type
+                    title: type
+                    _required_: true
+                    type: string
+                    enum:
+                      - STRIPE
+                      - MIRROR
+                  disks:
+                    _name_: disks
+                    title: disks
+                    default: []
+                    _required_: true
+                    type: array
+                    items:
+                      - _name_: disk
+                        title: disk
+                        _required_: false
+                        type: string
+                additionalProperties: false
+                _name_: logvdevs
+                title: logvdevs
+                default: {}
+                _required_: false
+                _attrs_order_:
+                  - type
+                  - disks
+            spares:
+              _name_: spares
+              title: spares
+              default: []
+              type: array
+              items:
+                _name_: disk
+                title: disk
+                _required_: false
+                type: string
+          additionalProperties: false
+          _name_: topology
+          title: topology
+          default: {}
+          _attrs_order_:
+            - data
+            - special
+            - dedup
+            - cache
+            - log
+            - spares
+          description: |-
+            `topology` is a object which requires at least one `data` entry.
+            All of `data` entries (vdevs) require to be of the same type.
+            Example of `topology`:
+        allow_duplicate_serials:
+          type: boolean
+          _name_: allow_duplicate_serials
+          title: allow_duplicate_serials
+          default: false
+        autotrim:
+          _name_: autotrim
+          title: autotrim
+          type: string
+          enum:
+            - "ON"
+            - "OFF"
+      additionalProperties: false
+      _name_: pool_update
+      title: pool_update
+      default: {}
+      _attrs_order_:
+        - topology
+        - allow_duplicate_serials
+        - autotrim
     pool_attach_0:
       type: integer
       _name_: oid
@@ -29425,7 +32621,56 @@ components:
           $ref: '#/components/schemas/pool_attach_0'
         pool_attach:
           $ref: '#/components/schemas/pool_attach_1'
-    pool_filesystem_choices_0:
+    pool_attachments_by_id:
+      type: object
+      properties: {}
+    pool_detach_by_id:
+      type: object
+      properties:
+        label:
+          _name_: label
+          title: label
+          type: string
+          description: '`label` is the vdev guid or device name.'
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - label
+    pool_expand_by_id:
+      type: object
+      properties: {}
+    pool_export_by_id:
+      type: object
+      properties:
+        cascade:
+          type: boolean
+          _name_: cascade
+          title: cascade
+          default: false
+          description: '`cascade` will delete all attachments of the given pool (`pool.attachments`).'
+        restart_services:
+          type: boolean
+          _name_: restart_services
+          title: restart_services
+          default: false
+          description: '`restart_services` will restart services that have open files on given pool.'
+        destroy:
+          type: boolean
+          _name_: destroy
+          title: destroy
+          default: false
+          description: '`destroy` will also PERMANENTLY destroy the pool/data.'
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - cascade
+        - restart_services
+        - destroy
+    pool_filesystem_choices:
       _name_: types
       title: types
       default:
@@ -29440,6 +32685,9 @@ components:
         enum:
           - FILESYSTEM
           - VOLUME
+    pool_get_disks_by_id:
+      type: object
+      properties: {}
     pool_get_instance_0:
       anyOf:
         - type: string
@@ -29524,7 +32772,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -29544,9 +32792,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/pool_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/pool_get_instance_1'
-    pool_get_instance_by_name_0:
+    pool_get_instance_by_name:
       _name_: name
       title: name
       type: string
@@ -29581,11 +32829,11 @@ components:
           $ref: '#/components/schemas/pool_import_disk_2'
         dst_path:
           $ref: '#/components/schemas/pool_import_disk_3'
-    pool_import_disk_autodetect_fs_type_0:
+    pool_import_disk_autodetect_fs_type:
       _name_: device
       title: device
       type: string
-    pool_import_pool_0:
+    pool_import_pool:
       type: object
       properties:
         guid:
@@ -29618,7 +32866,102 @@ components:
         - name
         - passphrase
         - enable_attachments
-    pool_dataset_create_0:
+    pool_is_upgraded_by_id:
+      type: object
+      properties: {}
+    pool_offline_by_id:
+      type: object
+      properties:
+        label:
+          _name_: label
+          title: label
+          type: string
+          description: '`label` is the vdev guid or device name.'
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - label
+    pool_online_by_id:
+      type: object
+      properties:
+        label:
+          _name_: label
+          title: label
+          type: string
+          description: '`label` is the vdev guid or device name.'
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - label
+    pool_processes_by_id:
+      type: object
+      properties: {}
+    pool_remove_by_id:
+      type: object
+      properties:
+        label:
+          _name_: label
+          title: label
+          type: string
+          description: '`label` is the vdev guid or device name.'
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - label
+    pool_replace_by_id:
+      type: object
+      properties:
+        label:
+          _name_: label
+          title: label
+          type: string
+          description: '`label` is the ZFS guid or a device name'
+        disk:
+          _name_: disk
+          title: disk
+          type: string
+          description: '`disk` is the identifier of a disk'
+        force:
+          type: boolean
+          _name_: force
+          title: force
+          default: false
+        preserve_settings:
+          type: boolean
+          _name_: preserve_settings
+          title: preserve_settings
+          default: true
+          description: |-
+            If `preserve_settings` is true, then settings (power management, S.M.A.R.T., etc.) of a disk being replaced
+            will be applied to a new disk.
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - label
+        - disk
+        - force
+        - preserve_settings
+    pool_scrub_by_id:
+      _name_: action
+      title: action
+      type: string
+      enum:
+        - START
+        - STOP
+        - PAUSE
+      description: '`action` can be either of "START", "STOP" or "PAUSE".'
+    pool_upgrade_by_id:
+      type: object
+      properties: {}
+    pool_dataset_create:
       type: object
       properties:
         name:
@@ -30140,6 +33483,444 @@ components:
         - inherit_encryption
         - user_properties
         - create_ancestors
+    pool_dataset_delete_by_id:
+      type: object
+      properties:
+        recursive:
+          type: boolean
+          _name_: recursive
+          title: recursive
+          default: false
+          description: '`recursive` will also delete/destroy all children datasets.'
+        force:
+          type: boolean
+          _name_: force
+          title: force
+          default: false
+          description: '`force` will force delete busy datasets.'
+      additionalProperties: false
+      _name_: dataset_delete
+      title: dataset_delete
+      default: {}
+      _attrs_order_:
+        - recursive
+        - force
+    pool_dataset_update_by_id:
+      type: object
+      properties:
+        volsize:
+          type: integer
+          _name_: volsize
+          title: volsize
+          description: |-
+            `volsize` is required for type=VOLUME and is supposed to be a multiple of the block size.
+            `sparse` and `volblocksize` are only used for type=VOLUME.
+        force_size:
+          type: boolean
+          _name_: force_size
+          title: force_size
+        comments:
+          _name_: comments
+          title: comments
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        sync:
+          _name_: sync
+          title: sync
+          enum:
+            - STANDARD
+            - ALWAYS
+            - DISABLED
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        snapdev:
+          _name_: snapdev
+          title: snapdev
+          enum:
+            - HIDDEN
+            - VISIBLE
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        compression:
+          _name_: compression
+          title: compression
+          enum:
+            - "OFF"
+            - LZ4
+            - GZIP
+            - GZIP-1
+            - GZIP-9
+            - ZSTD
+            - ZSTD-FAST
+            - ZLE
+            - LZJB
+            - ZSTD-1
+            - ZSTD-2
+            - ZSTD-3
+            - ZSTD-4
+            - ZSTD-5
+            - ZSTD-6
+            - ZSTD-7
+            - ZSTD-8
+            - ZSTD-9
+            - ZSTD-10
+            - ZSTD-11
+            - ZSTD-12
+            - ZSTD-13
+            - ZSTD-14
+            - ZSTD-15
+            - ZSTD-16
+            - ZSTD-17
+            - ZSTD-18
+            - ZSTD-19
+            - ZSTD-FAST-1
+            - ZSTD-FAST-2
+            - ZSTD-FAST-3
+            - ZSTD-FAST-4
+            - ZSTD-FAST-5
+            - ZSTD-FAST-6
+            - ZSTD-FAST-7
+            - ZSTD-FAST-8
+            - ZSTD-FAST-9
+            - ZSTD-FAST-10
+            - ZSTD-FAST-20
+            - ZSTD-FAST-30
+            - ZSTD-FAST-40
+            - ZSTD-FAST-50
+            - ZSTD-FAST-60
+            - ZSTD-FAST-70
+            - ZSTD-FAST-80
+            - ZSTD-FAST-90
+            - ZSTD-FAST-100
+            - ZSTD-FAST-500
+            - ZSTD-FAST-1000
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        atime:
+          _name_: atime
+          title: atime
+          enum:
+            - "ON"
+            - "OFF"
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        exec:
+          _name_: exec
+          title: exec
+          enum:
+            - "ON"
+            - "OFF"
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        managedby:
+          _name_: managedby
+          title: managedby
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        quota:
+          type: integer
+          _name_: quota
+          title: quota
+          nullable: true
+        quota_warning:
+          _name_: quota_warning
+          title: quota_warning
+          nullable: false
+          anyOf:
+            - type: integer
+            - type: string
+              enum:
+                - INHERIT
+        quota_critical:
+          _name_: quota_critical
+          title: quota_critical
+          nullable: false
+          anyOf:
+            - type: integer
+            - type: string
+              enum:
+                - INHERIT
+        refquota:
+          type: integer
+          _name_: refquota
+          title: refquota
+          nullable: true
+        refquota_warning:
+          _name_: refquota_warning
+          title: refquota_warning
+          nullable: false
+          anyOf:
+            - type: integer
+            - type: string
+              enum:
+                - INHERIT
+        refquota_critical:
+          _name_: refquota_critical
+          title: refquota_critical
+          nullable: false
+          anyOf:
+            - type: integer
+            - type: string
+              enum:
+                - INHERIT
+        reservation:
+          type: integer
+          _name_: reservation
+          title: reservation
+        refreservation:
+          type: integer
+          _name_: refreservation
+          title: refreservation
+        special_small_block_size:
+          _name_: special_small_block_size
+          title: special_small_block_size
+          nullable: false
+          anyOf:
+            - type: integer
+            - type: string
+              enum:
+                - INHERIT
+        copies:
+          _name_: copies
+          title: copies
+          nullable: false
+          anyOf:
+            - type: integer
+            - type: string
+              enum:
+                - INHERIT
+        snapdir:
+          _name_: snapdir
+          title: snapdir
+          enum:
+            - VISIBLE
+            - HIDDEN
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        deduplication:
+          _name_: deduplication
+          title: deduplication
+          enum:
+            - "ON"
+            - VERIFY
+            - "OFF"
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        checksum:
+          _name_: checksum
+          title: checksum
+          enum:
+            - "ON"
+            - "OFF"
+            - FLETCHER2
+            - FLETCHER4
+            - SHA256
+            - SHA512
+            - SKEIN
+            - EDONR
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        readonly:
+          _name_: readonly
+          title: readonly
+          enum:
+            - "ON"
+            - "OFF"
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        recordsize:
+          _name_: recordsize
+          title: recordsize
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        aclmode:
+          _name_: aclmode
+          title: aclmode
+          enum:
+            - PASSTHROUGH
+            - RESTRICTED
+            - DISCARD
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        acltype:
+          _name_: acltype
+          title: acltype
+          enum:
+            - "OFF"
+            - NFSV4
+            - POSIX
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        xattr:
+          _name_: xattr
+          title: xattr
+          default: SA
+          enum:
+            - "ON"
+            - SA
+          nullable: false
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - INHERIT
+        user_properties:
+          _name_: user_properties
+          title: user_properties
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                _name_: key
+                title: key
+                _required_: true
+                type: string
+              value:
+                _name_: value
+                title: value
+                _required_: true
+                type: string
+            additionalProperties: false
+            _name_: user_property
+            title: user_property
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - key
+              - value
+        create_ancestors:
+          type: boolean
+          _name_: create_ancestors
+          title: create_ancestors
+          default: false
+        user_properties_update:
+          _name_: user_properties_update
+          title: user_properties_update
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                _name_: key
+                title: key
+                _required_: true
+                type: string
+              value:
+                _name_: value
+                title: value
+                _required_: false
+                type: string
+              remove:
+                type: boolean
+                _name_: remove
+                title: remove
+                _required_: false
+            additionalProperties: false
+            _name_: user_property
+            title: user_property
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - key
+              - value
+              - remove
+      additionalProperties: false
+      _name_: pool_dataset_update
+      title: pool_dataset_update
+      default: {}
+      _attrs_order_:
+        - volsize
+        - force_size
+        - comments
+        - sync
+        - snapdev
+        - compression
+        - atime
+        - exec
+        - managedby
+        - quota
+        - quota_warning
+        - quota_critical
+        - refquota
+        - refquota_warning
+        - refquota_critical
+        - reservation
+        - refreservation
+        - special_small_block_size
+        - copies
+        - snapdir
+        - deduplication
+        - checksum
+        - readonly
+        - recordsize
+        - aclmode
+        - acltype
+        - xattr
+        - user_properties
+        - create_ancestors
+        - user_properties_update
+    pool_dataset_attachments_by_id:
+      type: object
+      properties: {}
     pool_dataset_change_key_0:
       _name_: id
       title: id
@@ -30354,7 +34135,7 @@ components:
           $ref: '#/components/schemas/pool_dataset_export_key_0'
         download:
           $ref: '#/components/schemas/pool_dataset_export_key_1'
-    pool_dataset_export_keys_0:
+    pool_dataset_export_keys:
       _name_: id
       title: id
       type: string
@@ -30445,7 +34226,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -30465,9 +34246,124 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/pool_dataset_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/pool_dataset_get_instance_1'
-    pool_dataset_inherit_parent_encryption_properties_0:
+    pool_dataset_get_quota_by_id_1:
+      _name_: quota_type
+      title: quota_type
+      type: string
+      enum:
+        - USER
+        - GROUP
+        - DATASET
+      description: |-
+        Return a list of the specified `quota_type` of  quotas on the ZFS dataset `ds`.
+        Support `query-filters` and `query-options`. used_bytes and used_percentage
+        may not instantly update as space is used.
+    pool_dataset_get_quota_by_id_2:
+      _name_: query-filters
+      title: query-filters
+      default: []
+      type: array
+      items: {}
+    pool_dataset_get_quota_by_id_3:
+      type: object
+      properties:
+        relationships:
+          type: boolean
+          _name_: relationships
+          title: relationships
+          default: true
+        extend:
+          _name_: extend
+          title: extend
+          default: null
+          type: string
+          nullable: true
+        extend_context:
+          _name_: extend_context
+          title: extend_context
+          default: null
+          type: string
+          nullable: true
+        prefix:
+          _name_: prefix
+          title: prefix
+          default: null
+          type: string
+          nullable: true
+        extra:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: extra
+          title: extra
+          default: {}
+          _attrs_order_: []
+        order_by:
+          _name_: order_by
+          title: order_by
+          default: []
+          type: array
+          items: {}
+        select:
+          _name_: select
+          title: select
+          default: []
+          type: array
+          items: {}
+        count:
+          type: boolean
+          _name_: count
+          title: count
+          default: false
+        get:
+          type: boolean
+          _name_: get
+          title: get
+          default: false
+        offset:
+          type: integer
+          _name_: offset
+          title: offset
+          default: 0
+        limit:
+          type: integer
+          _name_: limit
+          title: limit
+          default: 0
+        force_sql_filters:
+          type: boolean
+          _name_: force_sql_filters
+          title: force_sql_filters
+          default: false
+      additionalProperties: false
+      _name_: query-options
+      title: query-options
+      default: {}
+      _attrs_order_:
+        - relationships
+        - extend
+        - extend_context
+        - prefix
+        - extra
+        - order_by
+        - select
+        - count
+        - get
+        - offset
+        - limit
+        - force_sql_filters
+    pool_dataset_get_quota_by_id:
+      type: object
+      properties:
+        quota_type:
+          $ref: '#/components/schemas/pool_dataset_get_quota_by_id_1'
+        query-filters:
+          $ref: '#/components/schemas/pool_dataset_get_quota_by_id_2'
+        query-options:
+          $ref: '#/components/schemas/pool_dataset_get_quota_by_id_3'
+    pool_dataset_inherit_parent_encryption_properties:
       _name_: id
       title: id
       type: string
@@ -30513,11 +34409,410 @@ components:
           $ref: '#/components/schemas/pool_dataset_mountpoint_0'
         raise:
           $ref: '#/components/schemas/pool_dataset_mountpoint_1'
-    pool_dataset_recommended_zvol_blocksize_0:
+    pool_dataset_permission_by_id:
+      type: object
+      properties:
+        user:
+          _name_: user
+          title: user
+          type: string
+        group:
+          _name_: group
+          title: group
+          type: string
+        mode:
+          _name_: mode
+          title: mode
+          type: string
+          description: |-
+            Set permissions for a dataset `id`. Permissions may be specified as
+            either a posix `mode` or an `acl`. This method is a wrapper around
+            `filesystem.setperm`, `filesystem.setacl`, and `filesystem.chown`
+            `filesystem.setperm` is called if `mode` is specified.
+            `filesystem.setacl` is called if `acl` is specified or if the
+            option `set_default_acl` is selected.
+            `filesystem.chown` is called if neither `mode` nor `acl` is
+            specified.
+          nullable: true
+        acl:
+          anyOf:
+            - _name_: nfs4_acl
+              title: nfs4_acl
+              default: []
+              _required_: false
+              type: array
+              items:
+                - type: object
+                  properties:
+                    tag:
+                      _name_: tag
+                      title: tag
+                      _required_: false
+                      type: string
+                      enum:
+                        - owner@
+                        - group@
+                        - everyone@
+                        - USER
+                        - GROUP
+                    id:
+                      type:
+                        - integer
+                        - "null"
+                      _name_: id
+                      title: id
+                      _required_: false
+                    type:
+                      _name_: type
+                      title: type
+                      _required_: false
+                      type: string
+                      enum:
+                        - ALLOW
+                        - DENY
+                    perms:
+                      type: object
+                      properties:
+                        READ_DATA:
+                          type: boolean
+                          _name_: READ_DATA
+                          title: READ_DATA
+                          _required_: false
+                        WRITE_DATA:
+                          type: boolean
+                          _name_: WRITE_DATA
+                          title: WRITE_DATA
+                          _required_: false
+                        APPEND_DATA:
+                          type: boolean
+                          _name_: APPEND_DATA
+                          title: APPEND_DATA
+                          _required_: false
+                        READ_NAMED_ATTRS:
+                          type: boolean
+                          _name_: READ_NAMED_ATTRS
+                          title: READ_NAMED_ATTRS
+                          _required_: false
+                        WRITE_NAMED_ATTRS:
+                          type: boolean
+                          _name_: WRITE_NAMED_ATTRS
+                          title: WRITE_NAMED_ATTRS
+                          _required_: false
+                        EXECUTE:
+                          type: boolean
+                          _name_: EXECUTE
+                          title: EXECUTE
+                          _required_: false
+                        DELETE_CHILD:
+                          type: boolean
+                          _name_: DELETE_CHILD
+                          title: DELETE_CHILD
+                          _required_: false
+                        READ_ATTRIBUTES:
+                          type: boolean
+                          _name_: READ_ATTRIBUTES
+                          title: READ_ATTRIBUTES
+                          _required_: false
+                        WRITE_ATTRIBUTES:
+                          type: boolean
+                          _name_: WRITE_ATTRIBUTES
+                          title: WRITE_ATTRIBUTES
+                          _required_: false
+                        DELETE:
+                          type: boolean
+                          _name_: DELETE
+                          title: DELETE
+                          _required_: false
+                        READ_ACL:
+                          type: boolean
+                          _name_: READ_ACL
+                          title: READ_ACL
+                          _required_: false
+                        WRITE_ACL:
+                          type: boolean
+                          _name_: WRITE_ACL
+                          title: WRITE_ACL
+                          _required_: false
+                        WRITE_OWNER:
+                          type: boolean
+                          _name_: WRITE_OWNER
+                          title: WRITE_OWNER
+                          _required_: false
+                        SYNCHRONIZE:
+                          type: boolean
+                          _name_: SYNCHRONIZE
+                          title: SYNCHRONIZE
+                          _required_: false
+                        BASIC:
+                          _name_: BASIC
+                          title: BASIC
+                          _required_: false
+                          type: string
+                          enum:
+                            - FULL_CONTROL
+                            - MODIFY
+                            - READ
+                            - TRAVERSE
+                      additionalProperties: false
+                      _name_: perms
+                      title: perms
+                      default: {}
+                      _required_: false
+                      _attrs_order_:
+                        - READ_DATA
+                        - WRITE_DATA
+                        - APPEND_DATA
+                        - READ_NAMED_ATTRS
+                        - WRITE_NAMED_ATTRS
+                        - EXECUTE
+                        - DELETE_CHILD
+                        - READ_ATTRIBUTES
+                        - WRITE_ATTRIBUTES
+                        - DELETE
+                        - READ_ACL
+                        - WRITE_ACL
+                        - WRITE_OWNER
+                        - SYNCHRONIZE
+                        - BASIC
+                    flags:
+                      type: object
+                      properties:
+                        FILE_INHERIT:
+                          type: boolean
+                          _name_: FILE_INHERIT
+                          title: FILE_INHERIT
+                          _required_: false
+                        DIRECTORY_INHERIT:
+                          type: boolean
+                          _name_: DIRECTORY_INHERIT
+                          title: DIRECTORY_INHERIT
+                          _required_: false
+                        NO_PROPAGATE_INHERIT:
+                          type: boolean
+                          _name_: NO_PROPAGATE_INHERIT
+                          title: NO_PROPAGATE_INHERIT
+                          _required_: false
+                        INHERIT_ONLY:
+                          type: boolean
+                          _name_: INHERIT_ONLY
+                          title: INHERIT_ONLY
+                          _required_: false
+                        INHERITED:
+                          type: boolean
+                          _name_: INHERITED
+                          title: INHERITED
+                          _required_: false
+                        BASIC:
+                          _name_: BASIC
+                          title: BASIC
+                          _required_: false
+                          type: string
+                          enum:
+                            - INHERIT
+                            - NOINHERIT
+                      additionalProperties: false
+                      _name_: flags
+                      title: flags
+                      default: {}
+                      _required_: false
+                      _attrs_order_:
+                        - FILE_INHERIT
+                        - DIRECTORY_INHERIT
+                        - NO_PROPAGATE_INHERIT
+                        - INHERIT_ONLY
+                        - INHERITED
+                        - BASIC
+                  additionalProperties: false
+                  _name_: nfs4_ace
+                  title: nfs4_ace
+                  default: {}
+                  _required_: false
+                  _attrs_order_:
+                    - tag
+                    - id
+                    - type
+                    - perms
+                    - flags
+            - _name_: posix1e_acl
+              title: posix1e_acl
+              default: []
+              _required_: false
+              type: array
+              items:
+                - type: object
+                  properties:
+                    default:
+                      type: boolean
+                      _name_: default
+                      title: default
+                      default: false
+                      _required_: false
+                    tag:
+                      _name_: tag
+                      title: tag
+                      _required_: false
+                      type: string
+                      enum:
+                        - USER_OBJ
+                        - GROUP_OBJ
+                        - USER
+                        - GROUP
+                        - OTHER
+                        - MASK
+                    id:
+                      type: integer
+                      _name_: id
+                      title: id
+                      default: -1
+                      _required_: false
+                    perms:
+                      type: object
+                      properties:
+                        READ:
+                          type: boolean
+                          _name_: READ
+                          title: READ
+                          default: false
+                          _required_: false
+                        WRITE:
+                          type: boolean
+                          _name_: WRITE
+                          title: WRITE
+                          default: false
+                          _required_: false
+                        EXECUTE:
+                          type: boolean
+                          _name_: EXECUTE
+                          title: EXECUTE
+                          default: false
+                          _required_: false
+                      additionalProperties: false
+                      _name_: perms
+                      title: perms
+                      default: {}
+                      _required_: false
+                      _attrs_order_:
+                        - READ
+                        - WRITE
+                        - EXECUTE
+                  additionalProperties: false
+                  _name_: posix1e_ace
+                  title: posix1e_ace
+                  default: {}
+                  _required_: false
+                  _attrs_order_:
+                    - default
+                    - tag
+                    - id
+                    - perms
+          nullable: false
+          _name_: acl
+          description: |-
+            Set permissions for a dataset `id`. Permissions may be specified as
+            either a posix `mode` or an `acl`. This method is a wrapper around
+            `filesystem.setperm`, `filesystem.setacl`, and `filesystem.chown`
+            `filesystem.setacl` is called if `acl` is specified or if the
+            option `set_default_acl` is selected.
+            `filesystem.chown` is called if neither `mode` nor `acl` is
+            specified.
+        options:
+          type: object
+          properties:
+            set_default_acl:
+              type: boolean
+              _name_: set_default_acl
+              title: set_default_acl
+              default: false
+            stripacl:
+              type: boolean
+              _name_: stripacl
+              title: stripacl
+              default: false
+            recursive:
+              type: boolean
+              _name_: recursive
+              title: recursive
+              default: false
+            traverse:
+              type: boolean
+              _name_: traverse
+              title: traverse
+              default: false
+          additionalProperties: false
+          _name_: options
+          title: options
+          default: {}
+          _attrs_order_:
+            - set_default_acl
+            - stripacl
+            - recursive
+            - traverse
+          description: 'The following `options` are supported:'
+      additionalProperties: false
+      _name_: pool_dataset_permission
+      title: pool_dataset_permission
+      default: {}
+      _attrs_order_:
+        - user
+        - group
+        - mode
+        - acl
+        - options
+    pool_dataset_processes_by_id:
+      type: object
+      properties: {}
+    pool_dataset_promote_by_id:
+      type: object
+      properties: {}
+    pool_dataset_recommended_zvol_blocksize:
       _name_: pool
       title: pool
       type: string
-    pool_dataset_snapshot_count_0:
+    pool_dataset_set_quota_by_id:
+      _name_: quotas
+      title: quotas
+      default:
+        - quota_type: USER
+          id: "0"
+          quota_value: 0
+      type: array
+      items:
+        type: object
+        properties:
+          quota_type:
+            _name_: quota_type
+            title: quota_type
+            _required_: true
+            type: string
+            enum:
+              - DATASET
+              - USER
+              - USEROBJ
+              - GROUP
+              - GROUPOBJ
+          id:
+            _name_: id
+            title: id
+            _required_: true
+            type: string
+          quota_value:
+            type:
+              - integer
+              - "null"
+            _name_: quota_value
+            title: quota_value
+            _required_: true
+        additionalProperties: false
+        _name_: quota_entry
+        title: quota_entry
+        default: {}
+        _required_: false
+        _attrs_order_:
+          - quota_type
+          - id
+          - quota_value
+      description: '`quotas` specifies a list of `quota_entry` entries to apply to dataset.'
+    pool_dataset_snapshot_count:
       _name_: dataset
       title: dataset
       type: string
@@ -30616,11 +34911,11 @@ components:
           $ref: '#/components/schemas/pool_dataset_unlock_0'
         unlock_options:
           $ref: '#/components/schemas/pool_dataset_unlock_1'
-    pool_dataset_unlock_services_restart_choices_0:
+    pool_dataset_unlock_services_restart_choices:
       _name_: dataset
       title: dataset
       type: string
-    pool_dataset_userprop_create_0:
+    pool_dataset_userprop_create:
       type: object
       properties:
         id:
@@ -30652,6 +34947,37 @@ components:
       _attrs_order_:
         - id
         - property
+    pool_dataset_userprop_delete_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+      additionalProperties: false
+      _name_: dataset_user_prop_delete
+      title: dataset_user_prop_delete
+      default: {}
+      _attrs_order_:
+        - name
+    pool_dataset_userprop_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        value:
+          _name_: value
+          title: value
+          type: string
+      additionalProperties: false
+      _name_: dataset_user_prop_update
+      title: dataset_user_prop_update
+      default: {}
+      _attrs_order_:
+        - name
+        - value
     pool_dataset_userprop_get_instance_0:
       anyOf:
         - type: string
@@ -30736,7 +35062,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -30756,9 +35082,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/pool_dataset_userprop_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/pool_dataset_userprop_get_instance_1'
-    pool_resilver_update_0:
+    pool_resilver_update:
       type: object
       properties:
         begin:
@@ -30794,14 +35120,14 @@ components:
           description: '`weekday` follows crontab(5) values 0-7 (0 or 7 is Sun).'
       additionalProperties: false
       _name_: pool_resilver_update
-      title: pool_resilver_entry
+      title: pool_resilver_update
       default: {}
       _attrs_order_:
         - begin
         - end
         - enabled
         - weekday
-    pool_scrub_create_0:
+    pool_scrub_create:
       type: object
       properties:
         pool:
@@ -30872,6 +35198,82 @@ components:
         - description
         - schedule
         - enabled
+    pool_scrub_update_by_id:
+      type: object
+      properties:
+        pool:
+          type: integer
+          _name_: pool
+          title: pool
+        threshold:
+          type: integer
+          _name_: threshold
+          title: threshold
+          description: |-
+            `threshold` refers to the minimum amount of time in days has to be passed before
+            a scrub can run again.
+        description:
+          _name_: description
+          title: description
+          type: string
+        schedule:
+          type: object
+          properties:
+            minute:
+              _name_: minute
+              title: minute
+              default: "00"
+              type: string
+            hour:
+              _name_: hour
+              title: hour
+              default: "00"
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: "7"
+              type: string
+          additionalProperties: false
+          _name_: schedule
+          title: schedule
+          default: {}
+          _attrs_order_:
+            - minute
+            - hour
+            - dom
+            - month
+            - dow
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+        pool_name:
+          _name_: pool_name
+          title: pool_name
+          type: string
+      additionalProperties: false
+      _name_: pool_scrub_update
+      title: pool_scrub_update
+      default: {}
+      _attrs_order_:
+        - pool
+        - threshold
+        - description
+        - schedule
+        - enabled
+        - pool_name
     pool_scrub_get_instance_0:
       anyOf:
         - type: string
@@ -30956,7 +35358,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -30976,7 +35378,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/pool_scrub_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/pool_scrub_get_instance_1'
     pool_scrub_run_0:
       _name_: name
@@ -31014,7 +35416,7 @@ components:
           $ref: '#/components/schemas/pool_scrub_scrub_0'
         action:
           $ref: '#/components/schemas/pool_scrub_scrub_1'
-    pool_snapshottask_create_0:
+    pool_snapshottask_create:
       type: object
       properties:
         dataset:
@@ -31148,7 +35550,163 @@ components:
         - schedule
         - allow_empty
         - enabled
-    pool_snapshottask_foreseen_count_0:
+    pool_snapshottask_delete_by_id:
+      type: object
+      properties:
+        fixate_removal_date:
+          type: boolean
+          _name_: fixate_removal_date
+          title: fixate_removal_date
+          default: false
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - fixate_removal_date
+    pool_snapshottask_update_by_id:
+      type: object
+      properties:
+        dataset:
+          _name_: dataset
+          title: dataset
+          type: string
+          description: Create a Periodic Snapshot Task that will take snapshots of specified `dataset` at specified `schedule`.
+        recursive:
+          type: boolean
+          _name_: recursive
+          title: recursive
+          description: |-
+            Recursive snapshots can be created if `recursive` flag is enabled. You can `exclude` specific child datasets
+            or zvols from the snapshot.
+            Snapshots will be automatically destroyed after a certain amount of time, specified by
+        exclude:
+          _name_: exclude
+          title: exclude
+          default: []
+          type: array
+          items:
+            _name_: item
+            title: item
+            _required_: false
+            type: string
+          description: |-
+            Recursive snapshots can be created if `recursive` flag is enabled. You can `exclude` specific child datasets
+            or zvols from the snapshot.
+            Snapshots will be automatically destroyed after a certain amount of time, specified by
+        lifetime_value:
+          type: integer
+          _name_: lifetime_value
+          title: lifetime_value
+          description: |-
+            `lifetime_value` and `lifetime_unit`.
+            If multiple periodic tasks create snapshots at the same time (for example hourly and daily at 00:00) the snapshot
+            will be kept until the last of these tasks reaches its expiry time.
+        lifetime_unit:
+          _name_: lifetime_unit
+          title: lifetime_unit
+          type: string
+          enum:
+            - HOUR
+            - DAY
+            - WEEK
+            - MONTH
+            - YEAR
+          description: |-
+            `lifetime_value` and `lifetime_unit`.
+            If multiple periodic tasks create snapshots at the same time (for example hourly and daily at 00:00) the snapshot
+            will be kept until the last of these tasks reaches its expiry time.
+        naming_schema:
+          _name_: naming_schema
+          title: naming_schema
+          type: string
+          description: |-
+            Snapshots will be named according to `naming_schema` which is a `strftime`-like template for snapshot name
+            and must contain `%Y`, `%m`, `%d`, `%H` and `%M`.
+        schedule:
+          type: object
+          properties:
+            minute:
+              _name_: minute
+              title: minute
+              default: "00"
+              type: string
+            hour:
+              _name_: hour
+              title: hour
+              default: '*'
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: '*'
+              type: string
+            begin:
+              _name_: begin
+              title: begin
+              default: 00:00
+              type: string
+            end:
+              _name_: end
+              title: end
+              default: 23:59
+              type: string
+          additionalProperties: false
+          _name_: schedule
+          title: schedule
+          default: {}
+          _attrs_order_:
+            - minute
+            - hour
+            - dom
+            - month
+            - dow
+            - begin
+            - end
+          description: Create a Periodic Snapshot Task that will take snapshots of specified `dataset` at specified `schedule`.
+        allow_empty:
+          type: boolean
+          _name_: allow_empty
+          title: allow_empty
+          default: true
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+        fixate_removal_date:
+          type: boolean
+          _name_: fixate_removal_date
+          title: fixate_removal_date
+      additionalProperties: false
+      _name_: periodic_snapshot_update
+      title: periodic_snapshot_update
+      default: {}
+      _attrs_order_:
+        - dataset
+        - recursive
+        - exclude
+        - lifetime_value
+        - lifetime_unit
+        - naming_schema
+        - schedule
+        - allow_empty
+        - enabled
+        - fixate_removal_date
+    pool_snapshottask_delete_will_change_retention_for_by_id:
+      type: object
+      properties: {}
+    pool_snapshottask_foreseen_count:
       type: object
       properties:
         lifetime_value:
@@ -31307,7 +35865,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -31327,9 +35885,125 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/pool_snapshottask_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/pool_snapshottask_get_instance_1'
-    privilege_create_0:
+    pool_snapshottask_run_by_id:
+      type: object
+      properties: {}
+    pool_snapshottask_update_will_change_retention_for_by_id:
+      type: object
+      properties:
+        dataset:
+          _name_: dataset
+          title: dataset
+          type: string
+        recursive:
+          type: boolean
+          _name_: recursive
+          title: recursive
+        exclude:
+          _name_: exclude
+          title: exclude
+          default: []
+          type: array
+          items:
+            _name_: item
+            title: item
+            _required_: false
+            type: string
+        lifetime_value:
+          type: integer
+          _name_: lifetime_value
+          title: lifetime_value
+        lifetime_unit:
+          _name_: lifetime_unit
+          title: lifetime_unit
+          type: string
+          enum:
+            - HOUR
+            - DAY
+            - WEEK
+            - MONTH
+            - YEAR
+        naming_schema:
+          _name_: naming_schema
+          title: naming_schema
+          type: string
+        schedule:
+          type: object
+          properties:
+            minute:
+              _name_: minute
+              title: minute
+              default: "00"
+              type: string
+            hour:
+              _name_: hour
+              title: hour
+              default: '*'
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: '*'
+              type: string
+            begin:
+              _name_: begin
+              title: begin
+              default: 00:00
+              type: string
+            end:
+              _name_: end
+              title: end
+              default: 23:59
+              type: string
+          additionalProperties: false
+          _name_: schedule
+          title: schedule
+          default: {}
+          _attrs_order_:
+            - minute
+            - hour
+            - dom
+            - month
+            - dow
+            - begin
+            - end
+        allow_empty:
+          type: boolean
+          _name_: allow_empty
+          title: allow_empty
+          default: true
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+      additionalProperties: false
+      _name_: periodic_snapshot_update_will_change_retention
+      title: periodic_snapshot_update_will_change_retention
+      default: {}
+      _attrs_order_:
+        - dataset
+        - recursive
+        - exclude
+        - lifetime_value
+        - lifetime_unit
+        - naming_schema
+        - schedule
+        - allow_empty
+        - enabled
+    privilege_create:
       type: object
       properties:
         id:
@@ -31404,7 +36078,94 @@ components:
           title: web_shell
       additionalProperties: false
       _name_: privilege_create
-      title: privilege_entry
+      title: privilege_create
+      default: {}
+      _attrs_order_:
+        - id
+        - name
+        - local_groups
+        - ds_groups
+        - allowlist
+        - web_shell
+    privilege_update_by_id:
+      type: object
+      properties:
+        id:
+          type: integer
+          _name_: id
+          title: id
+          description: |-
+            Update the privilege `id`.
+            Creates a privilege.
+        name:
+          _name_: name
+          title: name
+          type: string
+          description: '`name` is a name for privilege (must be unique).'
+        local_groups:
+          _name_: local_groups
+          title: local_groups
+          default: []
+          type: array
+          items:
+            type: integer
+            _name_: local_group
+            title: local_group
+            _required_: false
+          description: '`local_groups` is a list of local user account group GIDs that gain this privilege.'
+        ds_groups:
+          _name_: ds_groups
+          title: ds_groups
+          default: []
+          type: array
+          items:
+            type: integer
+            _name_: ds_group
+            title: ds_group
+            _required_: false
+          description: '`ds_groups` is list of Directory Service group GIDs that will gain this privilege.'
+        allowlist:
+          _name_: allowlist
+          title: allowlist
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              method:
+                _name_: method
+                title: method
+                _required_: true
+                type: string
+                enum:
+                  - GET
+                  - POST
+                  - PUT
+                  - DELETE
+                  - CALL
+                  - SUBSCRIBE
+                  - '*'
+              resource:
+                _name_: resource
+                title: resource
+                _required_: true
+                type: string
+            additionalProperties: false
+            _name_: allowlist_item
+            title: allowlist_item
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - method
+              - resource
+          description: '`allowlist` is a list of API endpoints allowed for this privilege.'
+        web_shell:
+          type: boolean
+          _name_: web_shell
+          title: web_shell
+      additionalProperties: false
+      _name_: privilege_update
+      title: privilege_update
       default: {}
       _attrs_order_:
         - id
@@ -31497,7 +36258,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -31517,9 +36278,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/privilege_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/privilege_get_instance_1'
-    replication_create_0:
+    replication_create:
       type: object
       properties:
         name:
@@ -32143,7 +36904,631 @@ components:
         - retries
         - logging_level
         - enabled
-    replication_count_eligible_manual_snapshots_0:
+    replication_update_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+          description: '* `name` specifies a name for replication task'
+        direction:
+          _name_: direction
+          title: direction
+          type: string
+          enum:
+            - PUSH
+            - PULL
+          description: '* `direction` specifies whether task will `PUSH` or `PULL` snapshots'
+        transport:
+          _name_: transport
+          title: transport
+          type: string
+          enum:
+            - SSH
+            - SSH+NETCAT
+            - LOCAL
+          description: |-
+            * `transport` is a method of snapshots transfer:
+              * `SSH` transfers snapshots via SSH connection. This method is supported everywhere but does not achieve
+                great performance
+                `ssh_credentials` is a required field for this transport (Keychain Credential ID of type `SSH_CREDENTIALS`)
+              * `SSH+NETCAT` uses unencrypted connection for data transfer. This can only be used in trusted networks
+                and requires a port (specified by range from `netcat_active_side_port_min` to `netcat_active_side_port_max`)
+                to be open on `netcat_active_side`
+                `ssh_credentials` is also required for control connection
+              * `LOCAL` replicates to or from localhost
+        ssh_credentials:
+          type: integer
+          _name_: ssh_credentials
+          title: ssh_credentials
+          default: null
+          description: |-
+            * `transport` is a method of snapshots transfer:
+              * `SSH` transfers snapshots via SSH connection. This method is supported everywhere but does not achieve
+                great performance
+                `ssh_credentials` is a required field for this transport (Keychain Credential ID of type `SSH_CREDENTIALS`)
+              * `SSH+NETCAT` uses unencrypted connection for data transfer. This can only be used in trusted networks
+                and requires a port (specified by range from `netcat_active_side_port_min` to `netcat_active_side_port_max`)
+                to be open on `netcat_active_side`
+                `ssh_credentials` is also required for control connection
+              * `LOCAL` replicates to or from localhost
+          nullable: true
+        netcat_active_side:
+          _name_: netcat_active_side
+          title: netcat_active_side
+          default: null
+          type: string
+          enum:
+            - LOCAL
+            - REMOTE
+          description: |-
+            * `transport` is a method of snapshots transfer:
+              * `SSH` transfers snapshots via SSH connection. This method is supported everywhere but does not achieve
+                great performance
+                `ssh_credentials` is a required field for this transport (Keychain Credential ID of type `SSH_CREDENTIALS`)
+              * `SSH+NETCAT` uses unencrypted connection for data transfer. This can only be used in trusted networks
+                and requires a port (specified by range from `netcat_active_side_port_min` to `netcat_active_side_port_max`)
+                to be open on `netcat_active_side`
+                `ssh_credentials` is also required for control connection
+              * `LOCAL` replicates to or from localhost
+          nullable: true
+        netcat_active_side_listen_address:
+          _name_: netcat_active_side_listen_address
+          title: netcat_active_side_listen_address
+          default: null
+          type: string
+          nullable: true
+        netcat_active_side_port_min:
+          type: integer
+          _name_: netcat_active_side_port_min
+          title: netcat_active_side_port_min
+          default: null
+          description: |-
+            * `transport` is a method of snapshots transfer:
+              * `SSH` transfers snapshots via SSH connection. This method is supported everywhere but does not achieve
+                great performance
+                `ssh_credentials` is a required field for this transport (Keychain Credential ID of type `SSH_CREDENTIALS`)
+              * `SSH+NETCAT` uses unencrypted connection for data transfer. This can only be used in trusted networks
+                and requires a port (specified by range from `netcat_active_side_port_min` to `netcat_active_side_port_max`)
+                to be open on `netcat_active_side`
+                `ssh_credentials` is also required for control connection
+              * `LOCAL` replicates to or from localhost
+          nullable: true
+        netcat_active_side_port_max:
+          type: integer
+          _name_: netcat_active_side_port_max
+          title: netcat_active_side_port_max
+          default: null
+          description: |-
+            * `transport` is a method of snapshots transfer:
+              * `SSH` transfers snapshots via SSH connection. This method is supported everywhere but does not achieve
+                great performance
+                `ssh_credentials` is a required field for this transport (Keychain Credential ID of type `SSH_CREDENTIALS`)
+              * `SSH+NETCAT` uses unencrypted connection for data transfer. This can only be used in trusted networks
+                and requires a port (specified by range from `netcat_active_side_port_min` to `netcat_active_side_port_max`)
+                to be open on `netcat_active_side`
+                `ssh_credentials` is also required for control connection
+              * `LOCAL` replicates to or from localhost
+          nullable: true
+        netcat_passive_side_connect_address:
+          _name_: netcat_passive_side_connect_address
+          title: netcat_passive_side_connect_address
+          default: null
+          type: string
+          nullable: true
+        source_datasets:
+          _name_: source_datasets
+          title: source_datasets
+          default: []
+          type: array
+          items:
+            _name_: dataset
+            title: dataset
+            _required_: false
+            type: string
+          description: '* `source_datasets` is a non-empty list of datasets to replicate snapshots from'
+        target_dataset:
+          _name_: target_dataset
+          title: target_dataset
+          type: string
+          description: '* `target_dataset` is a dataset to put snapshots into. It must exist on target side'
+        recursive:
+          type: boolean
+          _name_: recursive
+          title: recursive
+          description: '* `recursive` and `exclude` have the same meaning as for Periodic Snapshot Task'
+        exclude:
+          _name_: exclude
+          title: exclude
+          default: []
+          type: array
+          items:
+            _name_: dataset
+            title: dataset
+            _required_: false
+            type: string
+          description: '* `recursive` and `exclude` have the same meaning as for Periodic Snapshot Task'
+        properties:
+          type: boolean
+          _name_: properties
+          title: properties
+          default: true
+          description: '* `properties` control whether we should send dataset properties along with snapshots'
+        properties_exclude:
+          _name_: properties_exclude
+          title: properties_exclude
+          default: []
+          type: array
+          items:
+            _name_: property
+            title: property
+            _required_: false
+            type: string
+        properties_override:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: properties_override
+          title: properties_override
+          default: {}
+          _attrs_order_: []
+        replicate:
+          type: boolean
+          _name_: replicate
+          title: replicate
+          default: false
+        encryption:
+          type: boolean
+          _name_: encryption
+          title: encryption
+          default: false
+        encryption_key:
+          _name_: encryption_key
+          title: encryption_key
+          default: null
+          type: string
+          nullable: true
+        encryption_key_format:
+          _name_: encryption_key_format
+          title: encryption_key_format
+          default: null
+          type: string
+          enum:
+            - HEX
+            - PASSPHRASE
+          nullable: true
+        encryption_key_location:
+          _name_: encryption_key_location
+          title: encryption_key_location
+          default: null
+          type: string
+          nullable: true
+        periodic_snapshot_tasks:
+          _name_: periodic_snapshot_tasks
+          title: periodic_snapshot_tasks
+          default: []
+          type: array
+          items:
+            type: integer
+            _name_: periodic_snapshot_task
+            title: periodic_snapshot_task
+            _required_: false
+          description: |-
+            * `periodic_snapshot_tasks` is a list of periodic snapshot task IDs that are sources of snapshots for this
+              replication task. Only push replication tasks can be bound to periodic snapshot tasks.
+        naming_schema:
+          _name_: naming_schema
+          title: naming_schema
+          default: []
+          type: array
+          items:
+            _name_: naming_schema
+            title: naming_schema
+            _required_: false
+            type: string
+          description: '* `naming_schema` is a list of naming schemas for pull replication'
+        also_include_naming_schema:
+          _name_: also_include_naming_schema
+          title: also_include_naming_schema
+          default: []
+          type: array
+          items:
+            _name_: naming_schema
+            title: naming_schema
+            _required_: false
+            type: string
+          description: '* `also_include_naming_schema` is a list of naming schemas for push replication'
+        name_regex:
+          _name_: name_regex
+          title: name_regex
+          default: null
+          type: string
+          description: '* `name_regex` will replicate all snapshots which names match specified regular expression'
+          nullable: true
+        auto:
+          type: boolean
+          _name_: auto
+          title: auto
+          description: |-
+            * `auto` allows replication to run automatically on schedule or after bound periodic snapshot task
+            * `schedule` is a schedule to run replication task. Only `auto` replication tasks without bound periodic
+              snapshot tasks can have a schedule
+        schedule:
+          type: object
+          properties:
+            minute:
+              _name_: minute
+              title: minute
+              default: "00"
+              type: string
+            hour:
+              _name_: hour
+              title: hour
+              default: '*'
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: '*'
+              type: string
+            begin:
+              _name_: begin
+              title: begin
+              default: 00:00
+              type: string
+            end:
+              _name_: end
+              title: end
+              default: 23:59
+              type: string
+          additionalProperties: false
+          _name_: schedule
+          title: schedule
+          default: null
+          _attrs_order_:
+            - minute
+            - hour
+            - dom
+            - month
+            - dow
+            - begin
+            - end
+          description: |-
+            * `auto` allows replication to run automatically on schedule or after bound periodic snapshot task
+            * `schedule` is a schedule to run replication task. Only `auto` replication tasks without bound periodic
+              snapshot tasks can have a schedule
+            * Enabling `only_matching_schedule` will only replicate snapshots that match `schedule` or
+              `restrict_schedule`
+        restrict_schedule:
+          type: object
+          properties:
+            minute:
+              _name_: minute
+              title: minute
+              default: "00"
+              type: string
+            hour:
+              _name_: hour
+              title: hour
+              default: '*'
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: '*'
+              type: string
+            begin:
+              _name_: begin
+              title: begin
+              default: 00:00
+              type: string
+            end:
+              _name_: end
+              title: end
+              default: 23:59
+              type: string
+          additionalProperties: false
+          _name_: restrict_schedule
+          title: restrict_schedule
+          default: null
+          _attrs_order_:
+            - minute
+            - hour
+            - dom
+            - month
+            - dow
+            - begin
+            - end
+          description: |-
+            * `restrict_schedule` restricts when replication task with bound periodic snapshot tasks runs. For example,
+              you can have periodic snapshot tasks that run every 15 minutes, but only run replication task every hour.
+            * Enabling `only_matching_schedule` will only replicate snapshots that match `schedule` or
+              `restrict_schedule`
+        only_matching_schedule:
+          type: boolean
+          _name_: only_matching_schedule
+          title: only_matching_schedule
+          default: false
+          description: |-
+            * Enabling `only_matching_schedule` will only replicate snapshots that match `schedule` or
+              `restrict_schedule`
+        allow_from_scratch:
+          type: boolean
+          _name_: allow_from_scratch
+          title: allow_from_scratch
+          default: false
+          description: |-
+            * `allow_from_scratch` will destroy all snapshots on target side and replicate everything from scratch if none
+              of the snapshots on target side matches source snapshots
+        readonly:
+          _name_: readonly
+          title: readonly
+          default: SET
+          type: string
+          enum:
+            - SET
+            - REQUIRE
+            - IGNORE
+          description: |-
+            * `readonly` controls destination datasets readonly property:
+              * `SET` will set all destination datasets to readonly=on after finishing the replication
+              * `REQUIRE` will require all existing destination datasets to have readonly=on property
+              * `IGNORE` will avoid this kind of behavior
+        hold_pending_snapshots:
+          type: boolean
+          _name_: hold_pending_snapshots
+          title: hold_pending_snapshots
+          default: false
+          description: |-
+            * `hold_pending_snapshots` will prevent source snapshots from being deleted by retention of replication fails
+              for some reason
+        retention_policy:
+          _name_: retention_policy
+          title: retention_policy
+          type: string
+          enum:
+            - SOURCE
+            - CUSTOM
+            - NONE
+          description: |-
+            * `retention_policy` specifies how to delete old snapshots on target side:
+              * `SOURCE` deletes snapshots that are absent on source side
+              * `CUSTOM` deletes snapshots that are older than `lifetime_value` and `lifetime_unit`
+              * `NONE` does not delete any snapshots
+        lifetime_value:
+          type: integer
+          _name_: lifetime_value
+          title: lifetime_value
+          default: null
+          description: |-
+            * `retention_policy` specifies how to delete old snapshots on target side:
+              * `SOURCE` deletes snapshots that are absent on source side
+              * `CUSTOM` deletes snapshots that are older than `lifetime_value` and `lifetime_unit`
+              * `NONE` does not delete any snapshots
+          nullable: true
+        lifetime_unit:
+          _name_: lifetime_unit
+          title: lifetime_unit
+          default: null
+          type: string
+          enum:
+            - HOUR
+            - DAY
+            - WEEK
+            - MONTH
+            - YEAR
+          description: |-
+            * `retention_policy` specifies how to delete old snapshots on target side:
+              * `SOURCE` deletes snapshots that are absent on source side
+              * `CUSTOM` deletes snapshots that are older than `lifetime_value` and `lifetime_unit`
+              * `NONE` does not delete any snapshots
+          nullable: true
+        lifetimes:
+          _name_: lifetimes
+          title: lifetimes
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              schedule:
+                type: object
+                properties:
+                  minute:
+                    _name_: minute
+                    title: minute
+                    default: '*'
+                    _required_: false
+                    type: string
+                  hour:
+                    _name_: hour
+                    title: hour
+                    default: '*'
+                    _required_: false
+                    type: string
+                  dom:
+                    _name_: dom
+                    title: dom
+                    default: '*'
+                    _required_: false
+                    type: string
+                  month:
+                    _name_: month
+                    title: month
+                    default: '*'
+                    _required_: false
+                    type: string
+                  dow:
+                    _name_: dow
+                    title: dow
+                    default: '*'
+                    _required_: false
+                    type: string
+                additionalProperties: false
+                _name_: schedule
+                title: schedule
+                default: {}
+                _required_: false
+                _attrs_order_:
+                  - minute
+                  - hour
+                  - dom
+                  - month
+                  - dow
+              lifetime_value:
+                type: integer
+                _name_: lifetime_value
+                title: lifetime_value
+                _required_: true
+              lifetime_unit:
+                _name_: lifetime_unit
+                title: lifetime_unit
+                _required_: true
+                type: string
+                enum:
+                  - HOUR
+                  - DAY
+                  - WEEK
+                  - MONTH
+                  - YEAR
+            additionalProperties: false
+            _name_: lifetime
+            title: lifetime
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - schedule
+              - lifetime_value
+              - lifetime_unit
+        compression:
+          _name_: compression
+          title: compression
+          default: null
+          type: string
+          enum:
+            - LZ4
+            - PIGZ
+            - PLZIP
+          description: '* `compression` compresses SSH stream. Available only for SSH transport'
+          nullable: true
+        speed_limit:
+          type: integer
+          _name_: speed_limit
+          title: speed_limit
+          default: null
+          description: '* `speed_limit` limits speed of SSH stream. Available only for SSH transport'
+          nullable: true
+        large_block:
+          type: boolean
+          _name_: large_block
+          title: large_block
+          default: true
+          description: '* `large_block`, `embed` and `compressed` are various ZFS stream flag documented in `man zfs send`'
+        embed:
+          type: boolean
+          _name_: embed
+          title: embed
+          default: false
+          description: '* `large_block`, `embed` and `compressed` are various ZFS stream flag documented in `man zfs send`'
+        compressed:
+          type: boolean
+          _name_: compressed
+          title: compressed
+          default: true
+          description: '* `large_block`, `embed` and `compressed` are various ZFS stream flag documented in `man zfs send`'
+        retries:
+          type: integer
+          _name_: retries
+          title: retries
+          default: 5
+          description: '* `retries` specifies number of retries before considering replication failed'
+        logging_level:
+          _name_: logging_level
+          title: logging_level
+          default: null
+          type: string
+          enum:
+            - DEBUG
+            - INFO
+            - WARNING
+            - ERROR
+          nullable: true
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+      additionalProperties: false
+      _name_: replication_update
+      title: replication_update
+      default: {}
+      _attrs_order_:
+        - name
+        - direction
+        - transport
+        - ssh_credentials
+        - netcat_active_side
+        - netcat_active_side_listen_address
+        - netcat_active_side_port_min
+        - netcat_active_side_port_max
+        - netcat_passive_side_connect_address
+        - source_datasets
+        - target_dataset
+        - recursive
+        - exclude
+        - properties
+        - properties_exclude
+        - properties_override
+        - replicate
+        - encryption
+        - encryption_key
+        - encryption_key_format
+        - encryption_key_location
+        - periodic_snapshot_tasks
+        - naming_schema
+        - also_include_naming_schema
+        - name_regex
+        - auto
+        - schedule
+        - restrict_schedule
+        - only_matching_schedule
+        - allow_from_scratch
+        - readonly
+        - hold_pending_snapshots
+        - retention_policy
+        - lifetime_value
+        - lifetime_unit
+        - lifetimes
+        - compression
+        - speed_limit
+        - large_block
+        - embed
+        - compressed
+        - retries
+        - logging_level
+        - enabled
+    replication_count_eligible_manual_snapshots:
       type: object
       properties:
         datasets:
@@ -32310,7 +37695,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -32330,7 +37715,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/replication_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/replication_get_instance_1'
     replication_list_datasets_0:
       _name_: transport
@@ -32354,7 +37739,28 @@ components:
           $ref: '#/components/schemas/replication_list_datasets_0'
         ssh_credentials:
           $ref: '#/components/schemas/replication_list_datasets_1'
-    replication_run_onetime_0:
+    replication_restore_by_id:
+      type: object
+      properties:
+        name:
+          _name_: name
+          title: name
+          type: string
+        target_dataset:
+          _name_: target_dataset
+          title: target_dataset
+          type: string
+      additionalProperties: false
+      _name_: replication_restore
+      title: replication_restore
+      default: {}
+      _attrs_order_:
+        - name
+        - target_dataset
+    replication_run_by_id:
+      type: object
+      properties: {}
+    replication_run_onetime:
       type: object
       properties:
         direction:
@@ -32760,7 +38166,7 @@ components:
           default: false
       additionalProperties: false
       _name_: replication_run_onetime
-      title: replication_create
+      title: replication_run_onetime
       default: {}
       _attrs_order_:
         - direction
@@ -32853,7 +38259,7 @@ components:
           $ref: '#/components/schemas/replication_target_unmatched_snapshots_3'
         ssh_credentials:
           $ref: '#/components/schemas/replication_target_unmatched_snapshots_4'
-    replication_config_update_0:
+    replication_config_update:
       type: object
       properties:
         max_parallel_replication_tasks:
@@ -32867,7 +38273,7 @@ components:
       default: {}
       _attrs_order_:
         - max_parallel_replication_tasks
-    reporting_update_0:
+    reporting_update:
       type: object
       properties:
         cpu_in_percentage:
@@ -32907,7 +38313,7 @@ components:
           title: confirm_rrd_destroy
       additionalProperties: false
       _name_: reporting_update
-      title: reporting_entry
+      title: reporting_update
       default: {}
       _attrs_order_:
         - cpu_in_percentage
@@ -33006,11 +38412,11 @@ components:
           $ref: '#/components/schemas/reporting_get_data_0'
         reporting_query:
           $ref: '#/components/schemas/reporting_get_data_1'
-    route_ipv4gw_reachable_0:
+    route_ipv4gw_reachable:
       _name_: ipv4_gateway
       title: ipv4_gateway
       type: string
-    rsyncd_update_0:
+    rsyncd_update:
       type: object
       properties:
         port:
@@ -33023,12 +38429,12 @@ components:
           type: string
       additionalProperties: false
       _name_: rsyncd_update
-      title: rsyncd_entry
+      title: rsyncd_update
       default: {}
       _attrs_order_:
         - port
         - auxiliary
-    rsyncmod_create_0:
+    rsyncmod_create:
       type: object
       properties:
         enabled:
@@ -33111,6 +38517,102 @@ components:
       additionalProperties: false
       _name_: rsyncmod_create
       title: rsyncmod_create
+      default: {}
+      _attrs_order_:
+        - enabled
+        - name
+        - comment
+        - path
+        - mode
+        - maxconn
+        - user
+        - group
+        - hostsallow
+        - hostsdeny
+        - auxiliary
+    rsyncmod_update_by_id:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+        name:
+          _name_: name
+          title: name
+          type: string
+        comment:
+          _name_: comment
+          title: comment
+          type: string
+        path:
+          _name_: path
+          title: path
+          type: string
+          description: |-
+            `path` represents the path to a dataset. Path length is limited to 1023 characters maximum as per the limit
+            enforced by FreeBSD. It is possible that we reach this max length recursively while transferring data. In that
+            case, the user must ensure the maximum path will not be too long or modify the recursed path to shorter
+            than the limit.
+        mode:
+          _name_: mode
+          title: mode
+          type: string
+          enum:
+            - RO
+            - RW
+            - WO
+        maxconn:
+          type: integer
+          _name_: maxconn
+          title: maxconn
+          description: |-
+            `maxconn` is an integer value representing the maximum number of simultaneous connections. Zero represents
+            unlimited.
+        user:
+          _name_: user
+          title: user
+          default: nobody
+          type: string
+        group:
+          _name_: group
+          title: group
+          default: nobody
+          type: string
+        hostsallow:
+          _name_: hostsallow
+          title: hostsallow
+          default: []
+          type: array
+          items:
+            _name_: hostsallow
+            title: hostsallow
+            _required_: false
+            type: string
+          description: |-
+            `hostsallow` is a list of patterns to match hostname/ip address of a connecting client. If list is empty,
+            all hosts are allowed.
+        hostsdeny:
+          _name_: hostsdeny
+          title: hostsdeny
+          default: []
+          type: array
+          items:
+            _name_: hostdeny
+            title: hostdeny
+            _required_: false
+            type: string
+          description: |-
+            `hostsdeny` is a list of patterns to match hostname/ip address of a connecting client. If the pattern is
+            matched, access is denied to the client. If no client should be denied, this should be left empty.
+        auxiliary:
+          _name_: auxiliary
+          title: auxiliary
+          type: string
+      additionalProperties: false
+      _name_: rsyncmod_update
+      title: rsyncmod_update
       default: {}
       _attrs_order_:
         - enabled
@@ -33208,7 +38710,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -33228,9 +38730,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/rsyncmod_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/rsyncmod_get_instance_1'
-    rsynctask_create_0:
+    rsynctask_create:
       type: object
       properties:
         path:
@@ -33436,6 +38938,212 @@ components:
         - delayupdates
         - extra
         - enabled
+    rsynctask_update_by_id:
+      type: object
+      properties:
+        path:
+          _name_: path
+          title: path
+          type: string
+          description: See the comment in Rsyncmod about `path` length limits.
+        user:
+          _name_: user
+          title: user
+          type: string
+          description: |-
+            In SSH mode, if `ssh_credentials` (a keychain credential of `SSH_CREDENTIALS` type) is specified then it is used
+            to connect to the remote host. If it is not specified, then keys in `user`'s .ssh directory are used.
+        mode:
+          _name_: mode
+          title: mode
+          default: MODULE
+          type: string
+          enum:
+            - MODULE
+            - SSH
+          description: |-
+            `mode` represents different operating mechanisms for Rsync i.e Rsync Module mode / Rsync SSH mode.
+            `remotemodule` is the name of remote module, this attribute should be specified when `mode` is set to MODULE.
+        remotehost:
+          _name_: remotehost
+          title: remotehost
+          default: null
+          type: string
+          description: |-
+            `remotehost` is ip address or hostname of the remote system. If username differs on the remote host,
+            "username@remote_host" format should be used.
+            `remotehost` and `remoteport` are not used in this case.
+          nullable: true
+        remoteport:
+          type: integer
+          _name_: remoteport
+          title: remoteport
+          default: null
+          description: '`remotehost` and `remoteport` are not used in this case.'
+          nullable: true
+        remotemodule:
+          _name_: remotemodule
+          title: remotemodule
+          default: null
+          type: string
+          description: '`remotemodule` is the name of remote module, this attribute should be specified when `mode` is set to MODULE.'
+          nullable: true
+        ssh_credentials:
+          type: integer
+          _name_: ssh_credentials
+          title: ssh_credentials
+          default: null
+          description: |-
+            In SSH mode, if `ssh_credentials` (a keychain credential of `SSH_CREDENTIALS` type) is specified then it is used
+            to connect to the remote host. If it is not specified, then keys in `user`'s .ssh directory are used.
+          nullable: true
+        remotepath:
+          _name_: remotepath
+          title: remotepath
+          type: string
+          description: '`remotepath` specifies the path on the remote system.'
+        validate_rpath:
+          type: boolean
+          _name_: validate_rpath
+          title: validate_rpath
+          default: true
+          description: '`validate_rpath` is a boolean which when sets validates the existence of the remote path.'
+        direction:
+          _name_: direction
+          title: direction
+          default: PUSH
+          type: string
+          enum:
+            - PULL
+            - PUSH
+          description: '`direction` specifies if data should be PULLED or PUSHED from the remote system.'
+        desc:
+          _name_: desc
+          title: desc
+          type: string
+        schedule:
+          type: object
+          properties:
+            minute:
+              _name_: minute
+              title: minute
+              default: "00"
+              type: string
+            hour:
+              _name_: hour
+              title: hour
+              default: '*'
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: '*'
+              type: string
+          additionalProperties: false
+          _name_: schedule
+          title: schedule
+          default: {}
+          _attrs_order_:
+            - minute
+            - hour
+            - dom
+            - month
+            - dow
+        recursive:
+          type: boolean
+          _name_: recursive
+          title: recursive
+        times:
+          type: boolean
+          _name_: times
+          title: times
+        compress:
+          type: boolean
+          _name_: compress
+          title: compress
+          description: '`compress` when set reduces the size of the data which is to be transmitted.'
+        archive:
+          type: boolean
+          _name_: archive
+          title: archive
+          description: |-
+            `archive` when set makes rsync run recursively, preserving symlinks, permissions, modification times, group,
+            and special files.
+        delete:
+          type: boolean
+          _name_: delete
+          title: delete
+          description: '`delete` when set deletes files in the destination directory which do not exist in the source directory.'
+        quiet:
+          type: boolean
+          _name_: quiet
+          title: quiet
+        preserveperm:
+          type: boolean
+          _name_: preserveperm
+          title: preserveperm
+          description: '`preserveperm` when set preserves original file permissions.'
+        preserveattr:
+          type: boolean
+          _name_: preserveattr
+          title: preserveattr
+        delayupdates:
+          type: boolean
+          _name_: delayupdates
+          title: delayupdates
+        extra:
+          _name_: extra
+          title: extra
+          default: []
+          type: array
+          items:
+            _name_: extra
+            title: extra
+            _required_: false
+            type: string
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+      additionalProperties: false
+      _name_: rsync_task_update
+      title: rsync_task_update
+      default: {}
+      _attrs_order_:
+        - path
+        - user
+        - mode
+        - remotehost
+        - remoteport
+        - remotemodule
+        - ssh_credentials
+        - remotepath
+        - validate_rpath
+        - direction
+        - desc
+        - schedule
+        - recursive
+        - times
+        - compress
+        - archive
+        - delete
+        - quiet
+        - preserveperm
+        - preserveattr
+        - delayupdates
+        - extra
+        - enabled
     rsynctask_get_instance_0:
       anyOf:
         - type: string
@@ -33520,7 +39228,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -33540,9 +39248,12 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/rsynctask_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/rsynctask_get_instance_1'
-    s3_update_0:
+    rsynctask_run_by_id:
+      type: object
+      properties: {}
+    s3_update:
       type: object
       properties:
         bindip:
@@ -33588,7 +39299,7 @@ components:
           nullable: true
       additionalProperties: false
       _name_: s3_update
-      title: s3_entry
+      title: s3_update
       default: {}
       _attrs_order_:
         - bindip
@@ -33600,6 +39311,20 @@ components:
         - tls_server_uri
         - storage_path
         - certificate
+    service_update_by_id:
+      type: object
+      properties:
+        enable:
+          type: boolean
+          _name_: enable
+          title: enable
+          default: false
+      additionalProperties: false
+      _name_: service-update
+      title: service-update
+      default: {}
+      _attrs_order_:
+        - enable
     service_get_instance_0:
       anyOf:
         - type: string
@@ -33684,7 +39409,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -33704,7 +39429,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/service_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/service_get_instance_1'
     service_reload_0:
       _name_: service
@@ -33800,11 +39525,11 @@ components:
           $ref: '#/components/schemas/service_start_0'
         service-control:
           $ref: '#/components/schemas/service_start_1'
-    service_started_0:
+    service_started:
       _name_: service
       title: service
       type: string
-    service_started_or_enabled_0:
+    service_started_or_enabled:
       _name_: service
       title: service
       type: string
@@ -33856,7 +39581,7 @@ components:
           $ref: '#/components/schemas/service_terminate_process_0'
         timeout:
           $ref: '#/components/schemas/service_terminate_process_1'
-    sharing_nfs_create_0:
+    sharing_nfs_create:
       type: object
       properties:
         path:
@@ -33975,6 +39700,125 @@ components:
         - mapall_group
         - security
         - enabled
+    sharing_nfs_update_by_id:
+      type: object
+      properties:
+        path:
+          _name_: path
+          title: path
+          type: string
+          description: '`path` local path to be exported.'
+        aliases:
+          _name_: aliases
+          title: aliases
+          default: []
+          type: array
+          items:
+            _name_: path
+            title: path
+            _required_: false
+            type: string
+          description: '`aliases` IGNORED, for now.'
+        comment:
+          _name_: comment
+          title: comment
+          default: ""
+          type: string
+        networks:
+          _name_: networks
+          title: networks
+          default: []
+          type: array
+          items:
+            _name_: network
+            title: network
+            _required_: false
+            type: string
+          description: |-
+            `networks` is a list of authorized networks that are allowed to access the share having format
+            "network/mask" CIDR notation. If empty, all networks are allowed.
+        hosts:
+          _name_: hosts
+          title: hosts
+          default: []
+          type: array
+          items:
+            _name_: host
+            title: host
+            _required_: false
+            type: string
+        ro:
+          type: boolean
+          _name_: ro
+          title: ro
+          default: false
+        quiet:
+          type: boolean
+          _name_: quiet
+          title: quiet
+          default: false
+        maproot_user:
+          _name_: maproot_user
+          title: maproot_user
+          default: null
+          type: string
+          nullable: true
+        maproot_group:
+          _name_: maproot_group
+          title: maproot_group
+          default: null
+          type: string
+          nullable: true
+        mapall_user:
+          _name_: mapall_user
+          title: mapall_user
+          default: null
+          type: string
+          nullable: true
+        mapall_group:
+          _name_: mapall_group
+          title: mapall_group
+          default: null
+          type: string
+          nullable: true
+        security:
+          _name_: security
+          title: security
+          default: []
+          type: array
+          items:
+            _name_: provider
+            title: provider
+            _required_: false
+            type: string
+            enum:
+              - SYS
+              - KRB5
+              - KRB5I
+              - KRB5P
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+      additionalProperties: false
+      _name_: sharingnfs_update
+      title: sharingnfs_update
+      default: {}
+      _attrs_order_:
+        - path
+        - aliases
+        - comment
+        - networks
+        - hosts
+        - ro
+        - quiet
+        - maproot_user
+        - maproot_group
+        - mapall_user
+        - mapall_group
+        - security
+        - enabled
     sharing_nfs_get_instance_0:
       anyOf:
         - type: string
@@ -34059,7 +39903,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -34079,9 +39923,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/sharing_nfs_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/sharing_nfs_get_instance_1'
-    sharing_smb_create_0:
+    sharing_smb_create:
       type: object
       properties:
         purpose:
@@ -34273,6 +40117,198 @@ components:
         - enabled
         - cluster_volname
         - afp
+    sharing_smb_update_by_id:
+      type: object
+      properties:
+        purpose:
+          _name_: purpose
+          title: purpose
+          default: DEFAULT_SHARE
+          type: string
+          enum:
+            - NO_PRESET
+            - DEFAULT_CLUSTER_SHARE
+            - DEFAULT_SHARE
+            - ENHANCED_TIMEMACHINE
+            - MULTI_PROTOCOL_NFS
+            - PRIVATE_DATASETS
+            - READ_ONLY
+            - WORM_DROPBOX
+          description: '`purpose` applies common configuration presets depending on intended purpose.'
+        path:
+          _name_: path
+          title: path
+          type: string
+          description: |-
+            `path` path to export over the SMB protocol. If server is clustered, then this path will be
+            relative to the `cluster_volname`.
+        path_suffix:
+          _name_: path_suffix
+          title: path_suffix
+          default: ""
+          type: string
+        home:
+          type: boolean
+          _name_: home
+          title: home
+          default: false
+        name:
+          _name_: name
+          title: name
+          type: string
+        comment:
+          _name_: comment
+          title: comment
+          default: ""
+          type: string
+        ro:
+          type: boolean
+          _name_: ro
+          title: ro
+          default: false
+          description: '`ro` when enabled, prohibits write access to the share.'
+        browsable:
+          type: boolean
+          _name_: browsable
+          title: browsable
+          default: true
+        timemachine:
+          type: boolean
+          _name_: timemachine
+          title: timemachine
+          default: false
+          description: '`timemachine` when set, enables Time Machine backups for this share.'
+        timemachine_quota:
+          type: integer
+          _name_: timemachine_quota
+          title: timemachine_quota
+          default: 0
+        recyclebin:
+          type: boolean
+          _name_: recyclebin
+          title: recyclebin
+          default: false
+        guestok:
+          type: boolean
+          _name_: guestok
+          title: guestok
+          default: false
+          description: '`guestok` when enabled, allows access to this share without a password.'
+        abe:
+          type: boolean
+          _name_: abe
+          title: abe
+          default: false
+        hostsallow:
+          _name_: hostsallow
+          title: hostsallow
+          default: []
+          type: array
+          items: {}
+          description: |-
+            `hostsallow` is a list of hostnames / IP addresses which have access to this share.
+            `hostsdeny` is a list of hostnames / IP addresses which are not allowed access to this share. If a handful
+            of hostnames are to be only allowed access, `hostsdeny` can be passed "ALL" which means that it will deny
+            access to ALL hostnames except for the ones which have been listed in `hostsallow`.
+        hostsdeny:
+          _name_: hostsdeny
+          title: hostsdeny
+          default: []
+          type: array
+          items: {}
+          description: |-
+            `hostsdeny` is a list of hostnames / IP addresses which are not allowed access to this share. If a handful
+            of hostnames are to be only allowed access, `hostsdeny` can be passed "ALL" which means that it will deny
+            access to ALL hostnames except for the ones which have been listed in `hostsallow`.
+        aapl_name_mangling:
+          type: boolean
+          _name_: aapl_name_mangling
+          title: aapl_name_mangling
+          default: false
+        acl:
+          type: boolean
+          _name_: acl
+          title: acl
+          default: true
+          description: '`acl` enables support for storing the SMB Security Descriptor as a Filesystem ACL.'
+        durablehandle:
+          type: boolean
+          _name_: durablehandle
+          title: durablehandle
+          default: true
+        shadowcopy:
+          type: boolean
+          _name_: shadowcopy
+          title: shadowcopy
+          default: true
+          description: '`shadowcopy` enables support for the volume shadow copy service.'
+        streams:
+          type: boolean
+          _name_: streams
+          title: streams
+          default: true
+          description: '`streams` enables support for storing alternate datastreams as filesystem extended attributes.'
+        fsrvp:
+          type: boolean
+          _name_: fsrvp
+          title: fsrvp
+          default: false
+          description: |-
+            `fsrvp` enables support for the filesystem remote VSS protocol. This allows clients to create
+            ZFS snapshots through RPC.
+        auxsmbconf:
+          _name_: auxsmbconf
+          title: auxsmbconf
+          default: ""
+          type: string
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+        cluster_volname:
+          _name_: cluster_volname
+          title: cluster_volname
+          default: ""
+          type: string
+          description: |-
+            `path` path to export over the SMB protocol. If server is clustered, then this path will be
+            relative to the `cluster_volname`.
+        afp:
+          type: boolean
+          _name_: afp
+          title: afp
+          default: false
+      additionalProperties: false
+      _name_: sharingsmb_update
+      title: sharingsmb_update
+      default: {}
+      _attrs_order_:
+        - purpose
+        - path
+        - path_suffix
+        - home
+        - name
+        - comment
+        - ro
+        - browsable
+        - timemachine
+        - timemachine_quota
+        - recyclebin
+        - guestok
+        - abe
+        - hostsallow
+        - hostsdeny
+        - aapl_name_mangling
+        - acl
+        - durablehandle
+        - shadowcopy
+        - streams
+        - fsrvp
+        - auxsmbconf
+        - enabled
+        - cluster_volname
+        - afp
     sharing_smb_get_instance_0:
       anyOf:
         - type: string
@@ -34357,7 +40393,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -34377,9 +40413,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/sharing_smb_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/sharing_smb_get_instance_1'
-    sharing_webdav_create_0:
+    sharing_webdav_create:
       type: object
       properties:
         perm:
@@ -34413,6 +40449,48 @@ components:
       additionalProperties: false
       _name_: webdav_share_create
       title: webdav_share_create
+      default: {}
+      _attrs_order_:
+        - perm
+        - ro
+        - comment
+        - name
+        - path
+        - enabled
+    sharing_webdav_update_by_id:
+      type: object
+      properties:
+        perm:
+          type: boolean
+          _name_: perm
+          title: perm
+          default: true
+        ro:
+          type: boolean
+          _name_: ro
+          title: ro
+          default: false
+          description: '`ro` when enabled prohibits users from writing to this share.'
+        comment:
+          _name_: comment
+          title: comment
+          type: string
+        name:
+          _name_: name
+          title: name
+          type: string
+        path:
+          _name_: path
+          title: path
+          type: string
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+      additionalProperties: false
+      _name_: webdav_share_update
+      title: webdav_share_update
       default: {}
       _attrs_order_:
         - perm
@@ -34505,7 +40583,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -34525,9 +40603,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/sharing_webdav_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/sharing_webdav_get_instance_1'
-    smart_update_0:
+    smart_update:
       type: object
       properties:
         interval:
@@ -34560,7 +40638,7 @@ components:
           title: critical
       additionalProperties: false
       _name_: smart_update
-      title: smart_entry
+      title: smart_update
       default: {}
       _attrs_order_:
         - interval
@@ -34568,7 +40646,7 @@ components:
         - difference
         - informational
         - critical
-    smart_test_create_0:
+    smart_test_create:
       type: object
       properties:
         schedule:
@@ -34646,7 +40724,85 @@ components:
         - all_disks
         - disks
         - type
-    smart_test_disk_choices_0:
+    smart_test_update_by_id:
+      type: object
+      properties:
+        schedule:
+          type: object
+          properties:
+            hour:
+              _name_: hour
+              title: hour
+              default: '*'
+              type: string
+            dom:
+              _name_: dom
+              title: dom
+              default: '*'
+              type: string
+            month:
+              _name_: month
+              title: month
+              default: '*'
+              type: string
+            dow:
+              _name_: dow
+              title: dow
+              default: '*'
+              type: string
+          additionalProperties: false
+          _name_: schedule
+          title: schedule
+          default: {}
+          _attrs_order_:
+            - hour
+            - dom
+            - month
+            - dow
+        desc:
+          _name_: desc
+          title: desc
+          type: string
+        all_disks:
+          type: boolean
+          _name_: all_disks
+          title: all_disks
+          default: false
+          description: '`all_disks` when enabled sets the task to cover all disks in which case `disks` is not required.'
+        disks:
+          _name_: disks
+          title: disks
+          default: []
+          type: array
+          items:
+            _name_: disk
+            title: disk
+            _required_: false
+            type: string
+          description: |-
+            `disks` is a list of valid disks which should be monitored in this task.
+            `all_disks` when enabled sets the task to cover all disks in which case `disks` is not required.
+        type:
+          _name_: type
+          title: type
+          type: string
+          enum:
+            - LONG
+            - SHORT
+            - CONVEYANCE
+            - OFFLINE
+          description: '`type` is specified to represent the type of SMART test to be executed.'
+      additionalProperties: false
+      _name_: smart_test_update
+      title: smart_test_update
+      default: {}
+      _attrs_order_:
+        - schedule
+        - desc
+        - all_disks
+        - disks
+        - type
+    smart_test_disk_choices:
       type: boolean
       _name_: full_disk
       title: full_disk
@@ -34735,7 +40891,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -34755,9 +40911,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/smart_test_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/smart_test_get_instance_1'
-    smart_test_manual_test_0:
+    smart_test_manual_test:
       _name_: disks
       title: disks
       default: []
@@ -34799,11 +40955,11 @@ components:
           - mode
           - type
       description: Run manual SMART tests for `disks`.
-    smart_test_query_for_disk_0:
+    smart_test_query_for_disk:
       _name_: disk
       title: disk
       type: string
-    smb_update_0:
+    smb_update:
       type: object
       properties:
         netbiosname:
@@ -34947,7 +41103,7 @@ components:
         - multichannel
         - bindip
         - smb_options
-    smb_get_remote_acl_0:
+    smb_get_remote_acl:
       type: object
       properties:
         server:
@@ -35167,7 +41323,7 @@ components:
           $ref: '#/components/schemas/smb_status_2'
         status_options:
           $ref: '#/components/schemas/smb_status_3'
-    smb_sharesec_create_0:
+    smb_sharesec_create:
       type: object
       properties:
         share_name:
@@ -35249,6 +41405,83 @@ components:
       default: {}
       _attrs_order_:
         - share_name
+        - share_acl
+    smb_sharesec_update_by_id:
+      type: object
+      properties:
+        share_acl:
+          _name_: share_acl
+          title: share_acl
+          default:
+            - ae_who_sid: S-1-1-0
+              ae_perm: FULL
+              ae_type: ALLOWED
+          type: array
+          items:
+            type: object
+            properties:
+              ae_who_sid:
+                _name_: ae_who_sid
+                title: ae_who_sid
+                default: null
+                _required_: false
+                type: string
+              ae_who_name:
+                type: object
+                properties:
+                  domain:
+                    _name_: domain
+                    title: domain
+                    default: ""
+                    _required_: false
+                    type: string
+                  name:
+                    _name_: name
+                    title: name
+                    default: ""
+                    _required_: false
+                    type: string
+                additionalProperties: false
+                _name_: ae_who_name
+                title: ae_who_name
+                default: null
+                _required_: false
+                _attrs_order_:
+                  - domain
+                  - name
+              ae_perm:
+                _name_: ae_perm
+                title: ae_perm
+                _required_: false
+                type: string
+                enum:
+                  - FULL
+                  - CHANGE
+                  - READ
+              ae_type:
+                _name_: ae_type
+                title: ae_type
+                _required_: false
+                type: string
+                enum:
+                  - ALLOWED
+                  - DENIED
+            additionalProperties: false
+            _name_: aclentry
+            title: aclentry
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - ae_who_sid
+              - ae_who_name
+              - ae_perm
+              - ae_type
+          description: '`share_acl` a list of ACL entries (dictionaries) with the following keys:'
+      additionalProperties: false
+      _name_: smbsharesec_update
+      title: smbsharesec_update
+      default: {}
+      _attrs_order_:
         - share_acl
     smb_sharesec_get_instance_0:
       anyOf:
@@ -35334,7 +41567,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -35354,7 +41587,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/smb_sharesec_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/smb_sharesec_get_instance_1'
     smb_sharesec_getacl_0:
       _name_: share_name
@@ -35386,7 +41619,7 @@ components:
           $ref: '#/components/schemas/smb_sharesec_getacl_0'
         options:
           $ref: '#/components/schemas/smb_sharesec_getacl_1'
-    snmp_update_0:
+    snmp_update:
       type: object
       properties:
         location:
@@ -35455,7 +41688,7 @@ components:
           title: zilstat
       additionalProperties: false
       _name_: snmp_update
-      title: snmp_entry
+      title: snmp_update
       default: {}
       _attrs_order_:
         - location
@@ -35471,7 +41704,7 @@ components:
         - loglevel
         - options
         - zilstat
-    ssh_update_0:
+    ssh_update:
       type: object
       properties:
         bindiface:
@@ -35559,7 +41792,7 @@ components:
           type: string
       additionalProperties: false
       _name_: ssh_update
-      title: ssh_entry
+      title: ssh_update
       default: {}
       _attrs_order_:
         - bindiface
@@ -35573,7 +41806,7 @@ components:
         - sftp_log_facility
         - weak_ciphers
         - options
-    staticroute_create_0:
+    staticroute_create:
       type: object
       properties:
         destination:
@@ -35593,7 +41826,33 @@ components:
           type: string
       additionalProperties: false
       _name_: staticroute_create
-      title: staticroute_entry
+      title: staticroute_create
+      default: {}
+      _attrs_order_:
+        - destination
+        - gateway
+        - description
+    staticroute_update_by_id:
+      type: object
+      properties:
+        destination:
+          _name_: destination
+          title: destination
+          type: string
+          description: Address families of `gateway` and `destination` should match when creating a static route.
+        gateway:
+          _name_: gateway
+          title: gateway
+          type: string
+          description: Address families of `gateway` and `destination` should match when creating a static route.
+        description:
+          _name_: description
+          title: description
+          default: ""
+          type: string
+      additionalProperties: false
+      _name_: staticroute_update
+      title: staticroute_update
       default: {}
       _attrs_order_:
         - destination
@@ -35683,7 +41942,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -35703,7 +41962,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/staticroute_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/staticroute_get_instance_1'
     stats_get_data_0:
       _name_: stats_list
@@ -35792,7 +42051,7 @@ components:
           $ref: '#/components/schemas/stats_get_dataset_info_0'
         type:
           $ref: '#/components/schemas/stats_get_dataset_info_1'
-    support_update_0:
+    support_update:
       type: object
       properties:
         enabled:
@@ -35834,7 +42093,7 @@ components:
           type: string
       additionalProperties: false
       _name_: support_update
-      title: support_entry
+      title: support_update
       default: {}
       _attrs_order_:
         - enabled
@@ -35846,7 +42105,7 @@ components:
         - secondary_title
         - secondary_email
         - secondary_phone
-    support_attach_ticket_0:
+    support_attach_ticket:
       type: object
       properties:
         ticket:
@@ -35869,12 +42128,12 @@ components:
         - ticket
         - filename
         - token
-    support_fetch_categories_0:
+    support_fetch_categories:
       _name_: token
       title: token
       default: ""
       type: string
-    support_new_ticket_0:
+    support_new_ticket:
       type: object
       properties:
         title:
@@ -35957,7 +42216,7 @@ components:
         - name
         - email
         - cc
-    system_feature_enabled_0:
+    system_feature_enabled:
       _name_: feature
       title: feature
       type: string
@@ -35965,11 +42224,11 @@ components:
         - DEDUP
         - FIBRECHANNEL
         - VM
-    system_license_update_0:
+    system_license_update:
       _name_: license
       title: license
       type: string
-    system_reboot_0:
+    system_reboot:
       type: object
       properties:
         delay:
@@ -35982,7 +42241,7 @@ components:
       default: {}
       _attrs_order_:
         - delay
-    system_shutdown_0:
+    system_shutdown:
       type: object
       properties:
         delay:
@@ -35995,7 +42254,7 @@ components:
       default: {}
       _attrs_order_:
         - delay
-    system_advanced_update_0:
+    system_advanced_update:
       type: object
       properties:
         advancedmode:
@@ -36150,7 +42409,7 @@ components:
           type: string
       additionalProperties: false
       _name_: system_advanced_update
-      title: system_advanced_entry
+      title: system_advanced_update
       default: {}
       _attrs_order_:
         - advancedmode
@@ -36180,7 +42439,7 @@ components:
         - isolated_gpu_pci_ids
         - kernel_extra_options
         - sed_passwd
-    system_advanced_update_gpu_pci_ids_0:
+    system_advanced_update_gpu_pci_ids:
       _name_: isolated_gpu_pci_ids
       title: isolated_gpu_pci_ids
       default: []
@@ -36190,7 +42449,7 @@ components:
         title: pci_id
         _required_: false
         type: string
-    system_general_update_0:
+    system_general_update:
       type: object
       properties:
         ui_httpsport:
@@ -36330,7 +42589,7 @@ components:
           nullable: true
       additionalProperties: false
       _name_: general_settings
-      title: system_general_entry
+      title: general_settings
       default: {}
       _attrs_order_:
         - ui_httpsport
@@ -36352,12 +42611,12 @@ components:
         - ui_certificate
         - rollback_timeout
         - ui_restart_delay
-    system_general_ui_restart_0:
+    system_general_ui_restart:
       type: integer
       _name_: delay
       title: delay
       default: 3
-    system_ntpserver_create_0:
+    system_ntpserver_create:
       type: object
       properties:
         address:
@@ -36411,6 +42670,69 @@ components:
       additionalProperties: false
       _name_: ntp_create
       title: ntp_create
+      default: {}
+      _attrs_order_:
+        - address
+        - burst
+        - iburst
+        - prefer
+        - minpoll
+        - maxpoll
+        - force
+    system_ntpserver_update_by_id:
+      type: object
+      properties:
+        address:
+          _name_: address
+          title: address
+          type: string
+          description: '`address` specifies the hostname/IP address of the NTP server.'
+        burst:
+          type: boolean
+          _name_: burst
+          title: burst
+          default: false
+          description: |-
+            `burst` when enabled makes sure that if server is reachable, sends a burst of eight packets instead of one.
+            This is designed to improve timekeeping quality with the server command.
+        iburst:
+          type: boolean
+          _name_: iburst
+          title: iburst
+          default: true
+          description: '`iburst` when enabled speeds up the initial synchronization, taking seconds rather than minutes.'
+        prefer:
+          type: boolean
+          _name_: prefer
+          title: prefer
+          default: false
+          description: |-
+            `prefer` marks the specified server as preferred. When all other things are equal, this host is chosen
+            for synchronization acquisition with the server command. It is recommended that they be used for servers with
+            time monitoring hardware.
+        minpoll:
+          type: integer
+          _name_: minpoll
+          title: minpoll
+          default: 6
+          description: |-
+            `minpoll` is minimum polling time in seconds. It must be a power of 2 and less than `maxpoll`.
+            `maxpoll` is maximum polling time in seconds. It must be a power of 2 and greater than `minpoll`.
+        maxpoll:
+          type: integer
+          _name_: maxpoll
+          title: maxpoll
+          default: 10
+          description: |-
+            `minpoll` is minimum polling time in seconds. It must be a power of 2 and less than `maxpoll`.
+            `maxpoll` is maximum polling time in seconds. It must be a power of 2 and greater than `minpoll`.
+        force:
+          type: boolean
+          _name_: force
+          title: force
+      additionalProperties: false
+      _name_: ntp_update
+      title: ntp_update
       default: {}
       _attrs_order_:
         - address
@@ -36504,7 +42826,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -36524,9 +42846,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/system_ntpserver_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/system_ntpserver_get_instance_1'
-    systemdataset_update_0:
+    systemdataset_update:
       type: object
       properties:
         pool:
@@ -36552,12 +42874,12 @@ components:
         - pool
         - pool_exclude
         - syslog
-    systemdataset_pool_choices_0:
+    systemdataset_pool_choices:
       type: boolean
       _name_: include_current_pool
       title: include_current_pool
       default: true
-    tftp_update_0:
+    tftp_update:
       type: object
       properties:
         newfiles:
@@ -36591,7 +42913,7 @@ components:
           type: string
       additionalProperties: false
       _name_: tftp_update
-      title: tftp_entry
+      title: tftp_update
       default: {}
       _attrs_order_:
         - newfiles
@@ -36601,7 +42923,7 @@ components:
         - umask
         - username
         - directory
-    truecommand_update_0:
+    truecommand_update:
       type: object
       properties:
         enabled:
@@ -36636,7 +42958,7 @@ components:
           $ref: '#/components/schemas/truenas_set_production_0'
         attach_debug:
           $ref: '#/components/schemas/truenas_set_production_1'
-    truenas_update_customer_information_0:
+    truenas_update_customer_information:
       type: object
       properties:
         company:
@@ -36885,7 +43207,7 @@ components:
         - physical_location
         - primary_use_case
         - other_primary_use_case
-    tunable_create_0:
+    tunable_create:
       type: object
       properties:
         type:
@@ -36930,6 +43252,34 @@ components:
       _attrs_order_:
         - type
         - var
+        - value
+        - comment
+        - enabled
+    tunable_update_by_id:
+      type: object
+      properties:
+        value:
+          _name_: value
+          title: value
+          type: string
+          description: |-
+            If `type` is `SYSCTL` then `var` is a sysctl name (e.g. `kernel.watchdog`) and `value` is its corresponding
+            value (e.g. `0`).
+        comment:
+          _name_: comment
+          title: comment
+          default: ""
+          type: string
+        enabled:
+          type: boolean
+          _name_: enabled
+          title: enabled
+          default: true
+      additionalProperties: false
+      _name_: tunable_update
+      title: tunable_update
+      default: {}
+      _attrs_order_:
         - value
         - comment
         - enabled
@@ -37017,7 +43367,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -37037,9 +43387,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/tunable_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/tunable_get_instance_1'
-    update_check_available_0:
+    update_check_available:
       type: object
       properties:
         train:
@@ -37052,7 +43402,7 @@ components:
       default: {}
       _attrs_order_:
         - train
-    update_file_0:
+    update_file:
       type: object
       properties:
         destination:
@@ -37066,7 +43416,7 @@ components:
       default: {}
       _attrs_order_:
         - destination
-    update_get_pending_0:
+    update_get_pending:
       _name_: path
       title: path
       default: null
@@ -37097,15 +43447,15 @@ components:
           $ref: '#/components/schemas/update_manual_0'
         options:
           $ref: '#/components/schemas/update_manual_1'
-    update_set_auto_download_0:
+    update_set_auto_download:
       type: boolean
       _name_: autocheck
       title: autocheck
-    update_set_train_0:
+    update_set_train:
       _name_: train
       title: train
       type: string
-    update_update_0:
+    update_update:
       type: object
       properties:
         train:
@@ -37124,7 +43474,7 @@ components:
       _attrs_order_:
         - train
         - reboot
-    ups_update_0:
+    ups_update:
       type: object
       properties:
         powerdown:
@@ -37223,7 +43573,7 @@ components:
           nullable: true
       additionalProperties: false
       _name_: ups_update
-      title: ups_entry
+      title: ups_update
       default: {}
       _attrs_order_:
         - powerdown
@@ -37245,7 +43595,7 @@ components:
         - remotehost
         - shutdown
         - shutdowncmd
-    user_create_0:
+    user_create:
       type: object
       properties:
         uid:
@@ -37383,6 +43733,151 @@ components:
         - sshpubkey
         - groups
         - attributes
+    user_delete_by_id:
+      type: object
+      properties:
+        delete_group:
+          type: boolean
+          _name_: delete_group
+          title: delete_group
+          default: true
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - delete_group
+    user_update_by_id:
+      type: object
+      properties:
+        uid:
+          type: integer
+          _name_: uid
+          title: uid
+          description: If `uid` is not provided it is automatically filled with the next one available.
+        username:
+          _name_: username
+          title: username
+          type: string
+        group:
+          type: integer
+          _name_: group
+          title: group
+          description: '`group` is required if `group_create` is false.'
+        home:
+          _name_: home
+          title: home
+          default: /nonexistent
+          type: string
+        home_mode:
+          _name_: home_mode
+          title: home_mode
+          default: "755"
+          type: string
+        shell:
+          _name_: shell
+          title: shell
+          default: /usr/bin/zsh
+          type: string
+          description: Available choices for `shell` can be retrieved with `user.shell_choices`.
+        full_name:
+          _name_: full_name
+          title: full_name
+          type: string
+        email:
+          _name_: email
+          title: email
+          default: null
+          type: string
+          nullable: true
+        password:
+          _name_: password
+          title: password
+          type: string
+          description: '`password` is required if `password_disabled` is false.'
+        password_disabled:
+          type: boolean
+          _name_: password_disabled
+          title: password_disabled
+          default: false
+          description: '`password` is required if `password_disabled` is false.'
+        locked:
+          type: boolean
+          _name_: locked
+          title: locked
+          default: false
+        smb:
+          type: boolean
+          _name_: smb
+          title: smb
+          default: true
+        sudo:
+          type: boolean
+          _name_: sudo
+          title: sudo
+          default: false
+        sudo_nopasswd:
+          type: boolean
+          _name_: sudo_nopasswd
+          title: sudo_nopasswd
+          default: false
+        sudo_commands:
+          _name_: sudo_commands
+          title: sudo_commands
+          default: []
+          type: array
+          items:
+            _name_: command
+            title: command
+            _required_: false
+            type: string
+        sshpubkey:
+          _name_: sshpubkey
+          title: sshpubkey
+          type: string
+          nullable: true
+        groups:
+          _name_: groups
+          title: groups
+          default: []
+          type: array
+          items:
+            type: integer
+            _name_: group
+            title: group
+            _required_: false
+        attributes:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: attributes
+          title: attributes
+          default: {}
+          _attrs_order_: []
+          description: '`attributes` is a general-purpose object for storing arbitrary user information.'
+      additionalProperties: false
+      _name_: user_update
+      title: user_update
+      default: {}
+      _attrs_order_:
+        - uid
+        - username
+        - group
+        - home
+        - home_mode
+        - shell
+        - full_name
+        - email
+        - password
+        - password_disabled
+        - locked
+        - smb
+        - sudo
+        - sudo_nopasswd
+        - sudo_commands
+        - sshpubkey
+        - groups
+        - attributes
     user_get_instance_0:
       anyOf:
         - type: string
@@ -37467,7 +43962,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -37487,9 +43982,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/user_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/user_get_instance_1'
-    user_get_user_obj_0:
+    user_get_user_obj:
       type: object
       properties:
         username:
@@ -37515,13 +44010,40 @@ components:
         - username
         - uid
         - get_groups
-    user_shell_choices_0:
+    user_pop_attribute_by_id:
+      _name_: key
+      title: key
+      type: string
+    user_set_attribute_by_id_1:
+      _name_: key
+      title: key
+      type: string
+      description: Set user general purpose `attributes` dictionary `key` to `value`.
+    user_set_attribute_by_id_2:
+      anyOf:
+        - type: string
+        - type: integer
+        - type: boolean
+        - type: object
+        - type: array
+      nullable: false
+      _name_: value
+      title: value
+      description: Set user general purpose `attributes` dictionary `key` to `value`.
+    user_set_attribute_by_id:
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/user_set_attribute_by_id_1'
+        value:
+          $ref: '#/components/schemas/user_set_attribute_by_id_2'
+    user_shell_choices:
       type: integer
       _name_: user_id
       title: user_id
       default: null
       nullable: true
-    vm_create_0:
+    vm_create:
       type: object
       properties:
         command_line_args:
@@ -37727,7 +44249,250 @@ components:
         - arch_type
         - machine_type
         - uuid
-    vm_get_available_memory_0:
+    vm_delete_by_id:
+      type: object
+      properties:
+        zvols:
+          type: boolean
+          _name_: zvols
+          title: zvols
+          default: false
+        force:
+          type: boolean
+          _name_: force
+          title: force
+          default: false
+      additionalProperties: false
+      _name_: vm_delete
+      title: vm_delete
+      default: {}
+      _attrs_order_:
+        - zvols
+        - force
+    vm_update_by_id:
+      type: object
+      properties:
+        command_line_args:
+          _name_: command_line_args
+          title: command_line_args
+          default: ""
+          type: string
+        cpu_mode:
+          _name_: cpu_mode
+          title: cpu_mode
+          default: CUSTOM
+          type: string
+          enum:
+            - CUSTOM
+            - HOST-MODEL
+            - HOST-PASSTHROUGH
+        cpu_model:
+          _name_: cpu_model
+          title: cpu_model
+          default: null
+          type: string
+          nullable: true
+        name:
+          _name_: name
+          title: name
+          type: string
+        description:
+          _name_: description
+          title: description
+          type: string
+        vcpus:
+          type: integer
+          _name_: vcpus
+          title: vcpus
+          default: 1
+          description: |-
+            Maximum of 16 guest virtual CPUs are allowed. By default, every virtual CPU is configured as a
+            separate package. Multiple cores can be configured per CPU by specifying `cores` attributes.
+            `vcpus` specifies total number of CPU sockets. `cores` specifies number of cores per socket. `threads`
+            specifies number of threads per core.
+        cores:
+          type: integer
+          _name_: cores
+          title: cores
+          default: 1
+          description: |-
+            Maximum of 16 guest virtual CPUs are allowed. By default, every virtual CPU is configured as a
+            separate package. Multiple cores can be configured per CPU by specifying `cores` attributes.
+            `vcpus` specifies total number of CPU sockets. `cores` specifies number of cores per socket. `threads`
+            specifies number of threads per core.
+        threads:
+          type: integer
+          _name_: threads
+          title: threads
+          default: 1
+          description: |-
+            Maximum of 16 guest virtual CPUs are allowed. By default, every virtual CPU is configured as a
+            separate package. Multiple cores can be configured per CPU by specifying `cores` attributes.
+            `vcpus` specifies total number of CPU sockets. `cores` specifies number of cores per socket. `threads`
+            specifies number of threads per core.
+        cpuset:
+          _name_: cpuset
+          title: cpuset
+          default: null
+          type: string
+          nullable: true
+        nodeset:
+          _name_: nodeset
+          title: nodeset
+          default: null
+          type: string
+          nullable: true
+        pin_vcpus:
+          type: boolean
+          _name_: pin_vcpus
+          title: pin_vcpus
+          default: false
+        suspend_on_snapshot:
+          type: boolean
+          _name_: suspend_on_snapshot
+          title: suspend_on_snapshot
+          default: false
+        memory:
+          type: integer
+          _name_: memory
+          title: memory
+        min_memory:
+          type: integer
+          _name_: min_memory
+          title: min_memory
+          default: null
+          nullable: true
+        hyperv_enlightenments:
+          type: boolean
+          _name_: hyperv_enlightenments
+          title: hyperv_enlightenments
+          default: false
+          description: |-
+            `hyperv_enlightenments` can be used to enable subset of predefined Hyper-V enlightenments for Windows guests.
+            These enlightenments improve performance and enable otherwise missing features.
+        bootloader:
+          _name_: bootloader
+          title: bootloader
+          default: UEFI
+          type: string
+          enum:
+            - UEFI
+            - UEFI_CSM
+        autostart:
+          type: boolean
+          _name_: autostart
+          title: autostart
+          default: true
+        hide_from_msr:
+          type: boolean
+          _name_: hide_from_msr
+          title: hide_from_msr
+          default: false
+          description: |-
+            `hide_from_msr` is a boolean which when set will hide the KVM hypervisor from standard MSR based discovery and
+            is useful to enable when doing GPU passthrough.
+        ensure_display_device:
+          type: boolean
+          _name_: ensure_display_device
+          title: ensure_display_device
+          default: true
+          description: |-
+            `ensure_display_device` when set ( the default ) will ensure that the guest always has access to a video device.
+            For headless installations like ubuntu server this is required for the guest to operate properly. However
+            for cases where consumer would like to use GPU passthrough and does not want a display device added should set
+            this to `false`.
+        time:
+          _name_: time
+          title: time
+          default: LOCAL
+          type: string
+          enum:
+            - LOCAL
+            - UTC
+        shutdown_timeout:
+          type: integer
+          _name_: shutdown_timeout
+          title: shutdown_timeout
+          default: 90
+          description: |-
+            `shutdown_timeout` indicates the time in seconds the system waits for the VM to cleanly shutdown. During system
+            shutdown, if the VM hasn't exited after a hardware shutdown signal has been sent by the system within
+            `shutdown_timeout` seconds, system initiates poweroff for the VM to stop it.
+        arch_type:
+          _name_: arch_type
+          title: arch_type
+          default: null
+          type: string
+          description: |-
+            `arch_type` refers to architecture type and can be specified for the guest. By default the value is `null` and
+            system in this case will choose a reasonable default based on host.
+            `machine_type` refers to machine type of the guest based on the architecture type selected with `arch_type`.
+            By default the value is `null` and system in this case will choose a reasonable default based on `arch_type`
+            configuration.
+          nullable: true
+        machine_type:
+          _name_: machine_type
+          title: machine_type
+          default: null
+          type: string
+          description: |-
+            `machine_type` refers to machine type of the guest based on the architecture type selected with `arch_type`.
+            By default the value is `null` and system in this case will choose a reasonable default based on `arch_type`
+            configuration.
+          nullable: true
+        uuid:
+          _name_: uuid
+          title: uuid
+          default: null
+          type: string
+          nullable: true
+        id:
+          type: integer
+          _name_: id
+          title: id
+          description: |-
+            1) If there is no device in the `devices` list which was previously attached to the VM, that device is
+               removed from the virtual machine.
+            2) Devices are updated in the `devices` list when they contain a valid `id` attribute that corresponds to
+               an existing device.
+            3) Devices that do not have an `id` attribute are created and attached to `id` VM.
+            Create a Virtual Machine (VM).
+      additionalProperties: false
+      _name_: vm_update
+      title: vm_update
+      default: {}
+      _attrs_order_:
+        - command_line_args
+        - cpu_mode
+        - cpu_model
+        - name
+        - description
+        - vcpus
+        - cores
+        - threads
+        - cpuset
+        - nodeset
+        - pin_vcpus
+        - suspend_on_snapshot
+        - memory
+        - min_memory
+        - hyperv_enlightenments
+        - bootloader
+        - autostart
+        - hide_from_msr
+        - ensure_display_device
+        - time
+        - shutdown_timeout
+        - arch_type
+        - machine_type
+        - uuid
+        - id
+    vm_clone_by_id:
+      _name_: name
+      title: name
+      default: null
+      type: string
+    vm_get_available_memory:
       type: boolean
       _name_: overcommit
       title: overcommit
@@ -37741,11 +44506,11 @@ components:
         1. Complete VM requested memory will be taken into account regardless of how much actual physical
            memory the VM is consuming
         2. System will not consider shrinkable ZFS ARC as free memory
-    vm_get_console_0:
+    vm_get_console:
       type: integer
       _name_: id
       title: id
-    vm_get_display_devices_0:
+    vm_get_display_devices:
       type: integer
       _name_: id
       title: id
@@ -37833,7 +44598,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -37853,23 +44618,72 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/vm_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/vm_get_instance_1'
-    vm_get_memory_usage_0:
+    vm_get_memory_usage:
       type: integer
       _name_: vm_id
       title: vm_id
-    vm_get_vm_memory_info_0:
+    vm_get_vm_memory_info:
       type: integer
       _name_: vm_id
       title: vm_id
       description: Returns memory information for `vm_id` VM if it is going to be started.
-    vm_log_file_path_0:
+    vm_log_file_path:
       type: integer
       _name_: id
       title: id
       description: Retrieve log file path of `id` VM.
-    vm_device_create_0:
+    vm_poweroff_by_id:
+      type: object
+      properties: {}
+    vm_restart_by_id:
+      type: object
+      properties: {}
+    vm_resume_by_id:
+      type: object
+      properties: {}
+    vm_start_by_id:
+      type: object
+      properties:
+        overcommit:
+          type: boolean
+          _name_: overcommit
+          title: overcommit
+          default: false
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - overcommit
+    vm_status_by_id:
+      type: object
+      properties: {}
+    vm_stop_by_id:
+      type: object
+      properties:
+        force:
+          type: boolean
+          _name_: force
+          title: force
+          default: false
+        force_after_timeout:
+          type: boolean
+          _name_: force_after_timeout
+          title: force_after_timeout
+          default: false
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - force
+        - force_after_timeout
+    vm_suspend_by_id:
+      type: object
+      properties: {}
+    vm_device_create:
       type: object
       properties:
         dtype:
@@ -37909,6 +44723,79 @@ components:
       additionalProperties: false
       _name_: vmdevice_create
       title: vmdevice_create
+      default: {}
+      _attrs_order_:
+        - dtype
+        - vm
+        - attributes
+        - order
+    vm_device_delete_by_id:
+      type: object
+      properties:
+        zvol:
+          type: boolean
+          _name_: zvol
+          title: zvol
+          default: false
+        raw_file:
+          type: boolean
+          _name_: raw_file
+          title: raw_file
+          default: false
+        force:
+          type: boolean
+          _name_: force
+          title: force
+          default: false
+      additionalProperties: false
+      _name_: vm_device_delete
+      title: vm_device_delete
+      default: {}
+      _attrs_order_:
+        - zvol
+        - raw_file
+        - force
+    vm_device_update_by_id:
+      type: object
+      properties:
+        dtype:
+          _name_: dtype
+          title: dtype
+          type: string
+          enum:
+            - NIC
+            - DISK
+            - CDROM
+            - PCI
+            - DISPLAY
+            - RAW
+            - USB
+          description: |-
+            Pass `attributes.size` to resize a `dtype` `RAW` device. The raw file will be resized.
+            If `dtype` is the `RAW` type and a new raw file is to be created, `attributes.exists` will be passed as false.
+            This means the API handles creating the raw file and raises the appropriate exception if file creation fails.
+        vm:
+          type: integer
+          _name_: vm
+          title: vm
+          description: Create a new device for the VM of id `vm`.
+        attributes:
+          type: object
+          properties: {}
+          additionalProperties: true
+          _name_: attributes
+          title: attributes
+          default: null
+          _attrs_order_: []
+        order:
+          type: integer
+          _name_: order
+          title: order
+          default: null
+          nullable: true
+      additionalProperties: false
+      _name_: vm_device_update
+      title: vm_device_update
       default: {}
       _attrs_order_:
         - dtype
@@ -37999,7 +44886,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -38019,17 +44906,17 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/vm_device_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/vm_device_get_instance_1'
-    vm_device_passthrough_device_0:
+    vm_device_passthrough_device:
       _name_: device
       title: device
       type: string
-    vm_device_usb_passthrough_device_0:
+    vm_device_usb_passthrough_device:
       _name_: device
       title: device
       type: string
-    vmware_create_0:
+    vmware_create:
       type: object
       properties:
         datastore:
@@ -38067,6 +44954,44 @@ components:
         - hostname
         - password
         - username
+    vmware_update_by_id:
+      type: object
+      properties:
+        datastore:
+          _name_: datastore
+          title: datastore
+          type: string
+        filesystem:
+          _name_: filesystem
+          title: filesystem
+          type: string
+        hostname:
+          _name_: hostname
+          title: hostname
+          type: string
+          description: |-
+            `hostname` is a valid IP address / hostname of a VMWare host. When clustering, this is the vCenter server for
+            the cluster.
+        password:
+          _name_: password
+          title: password
+          type: string
+          description: '`username` and `password` are the credentials used to authorize access to the VMWare host.'
+        username:
+          _name_: username
+          title: username
+          type: string
+          description: '`username` and `password` are the credentials used to authorize access to the VMWare host.'
+      additionalProperties: false
+      _name_: vmware_update
+      title: vmware_update
+      default: {}
+      _attrs_order_:
+        - datastore
+        - filesystem
+        - hostname
+        - password
+        - username
     vmware_dataset_has_vms_0:
       _name_: dataset
       title: dataset
@@ -38082,7 +45007,7 @@ components:
           $ref: '#/components/schemas/vmware_dataset_has_vms_0'
         recursive:
           $ref: '#/components/schemas/vmware_dataset_has_vms_1'
-    vmware_get_datastores_0:
+    vmware_get_datastores:
       type: object
       properties:
         hostname:
@@ -38189,7 +45114,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -38209,13 +45134,13 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/vmware_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/vmware_get_instance_1'
-    vmware_get_virtual_machines_0:
+    vmware_get_virtual_machines:
       type: integer
       _name_: pk
       title: pk
-    vmware_match_datastores_with_datasets_0:
+    vmware_match_datastores_with_datasets:
       type: object
       properties:
         hostname:
@@ -38238,7 +45163,7 @@ components:
         - hostname
         - username
         - password
-    webdav_update_0:
+    webdav_update:
       type: object
       properties:
         protocol:
@@ -38282,7 +45207,7 @@ components:
           nullable: true
       additionalProperties: false
       _name_: webdav_update
-      title: webdav_entry
+      title: webdav_update
       default: {}
       _attrs_order_:
         - protocol
@@ -38291,7 +45216,7 @@ components:
         - password
         - htauth
         - certssl
-    webui_image_create_0:
+    webui_image_create:
       type: object
       properties:
         identifier:
@@ -38388,7 +45313,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -38408,9 +45333,9 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/webui_image_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/webui_image_get_instance_1'
-    zfs_snapshot_create_0:
+    zfs_snapshot_create:
       type: object
       properties:
         dataset:
@@ -38471,7 +45396,68 @@ components:
         - suspend_vms
         - vmware_sync
         - properties
-    zfs_snapshot_clone_0:
+    zfs_snapshot_delete_by_id:
+      type: object
+      properties:
+        defer:
+          type: boolean
+          _name_: defer
+          title: defer
+          default: false
+        recursive:
+          type: boolean
+          _name_: recursive
+          title: recursive
+          default: false
+      additionalProperties: false
+      _name_: options
+      title: options
+      default: {}
+      _attrs_order_:
+        - defer
+        - recursive
+    zfs_snapshot_update_by_id:
+      type: object
+      properties:
+        user_properties_update:
+          _name_: user_properties_update
+          title: user_properties_update
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                _name_: key
+                title: key
+                _required_: true
+                type: string
+              value:
+                _name_: value
+                title: value
+                _required_: false
+                type: string
+              remove:
+                type: boolean
+                _name_: remove
+                title: remove
+                _required_: false
+            additionalProperties: false
+            _name_: user_property
+            title: user_property
+            default: {}
+            _required_: false
+            _attrs_order_:
+              - key
+              - value
+              - remove
+      additionalProperties: false
+      _name_: snapshot_update
+      title: snapshot_update
+      default: {}
+      _attrs_order_:
+        - user_properties_update
+    zfs_snapshot_clone:
       type: object
       properties:
         snapshot:
@@ -38582,7 +45568,7 @@ components:
           default: true
       additionalProperties: false
       _name_: query-options-get_instance
-      title: query-options
+      title: query-options-get_instance
       default: {}
       _attrs_order_:
         - relationships
@@ -38602,7 +45588,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/zfs_snapshot_get_instance_0'
-        query-options:
+        query-options-get_instance:
           $ref: '#/components/schemas/zfs_snapshot_get_instance_1'
     zfs_snapshot_hold_0:
       _name_: id
@@ -38656,7 +45642,7 @@ components:
           $ref: '#/components/schemas/zfs_snapshot_release_0'
         options:
           $ref: '#/components/schemas/zfs_snapshot_release_1'
-    zfs_snapshot_remove_0:
+    zfs_snapshot_remove:
       type: object
       properties:
         dataset:


### PR DESCRIPTION
I submitted two PRs to fix upstream doc generation issues:
- https://github.com/truenas/middleware/pull/10747
- https://github.com/truenas/middleware/pull/10748

The good news is that they were accepted :)
The bad news is that I suspect they won't release them until "catfish" or whatever they call their next release :(

I manually applied the fixes to a VM and generated these docs. However this is of course controversial:
- Technically they may never be in any "bluefin" release, so one could argue they shouldn't be included in `bluefin_original.yaml`
  - If we do include them, then any further updates to `bluefin_original.yaml` must also come from a patched version (otherwise it'll drop the fixes)
- The changes are indeed fixes, and I did them because without them, adding new routes would've required **far more** manual work than I'm prepared to do

If you are OK to merge these fixes, I pinky swear I'll provide updated (patched) `bluefin_original.yaml` files for any new bluefin patch versions.

If you prefer to not include these, we can either have them in a new release name "bluefinupstream", or I can maintain my fork until the next true release comes out, and then try to merge up to you on that release name.